### PR TITLE
add proguard tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ project(":unityLibrary").projectDir = file("./unityLibrary")
         }
     }
 ```
+  4. If you use `minifyEnabled true` and need to use UnityMessage in Flutter, please add proguard content below:
+```
+-keep class com.xraph.plugins.** {*;}
+```
   5. If you want unity in it's own activity as an alternative, just add this to your app `AndroidManifest.xml` file
 ```xml
         <activity


### PR DESCRIPTION
add proguard content when building release package and using onUnityMessage. otherwise will raise ClassNotFoundException in Android.