### PR TITLE
Fixed argument name in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 
+void main() {
+  runApp(MaterialApp(
+    home: UnityDemoScreen()
+  ));
+}
+
 class UnityDemoScreen extends StatefulWidget {
 
   UnityDemoScreen({Key key}) : super(key: key);
@@ -289,7 +295,7 @@ class _UnityDemoScreenState extends State<UnityDemoScreen>{
           child: Container(
             color: colorYellow,
             child: UnityWidget(
-              onUnityViewCreated: onUnityCreated,
+              onUnityCreated: onUnityCreated,
             ),
           ),
         ),
@@ -346,7 +352,7 @@ class _MyAppState extends State<MyApp> {
           child: Stack(
             children: <Widget>[
               UnityWidget(
-                  onUnityViewCreated: onUnityCreated,
+                  onUnityCreated: onUnityCreated,
                   isARScene: true,
                   onUnityMessage: onUnityMessage,
                   onUnitySceneLoaded: onUnitySceneLoaded,


### PR DESCRIPTION
The ReadMe contains deprecated argument names

onUnityViewCreated --> onUnityCreated

Also I've made the Vuforia wrapper example standalone runnable (By adding a MaterialApp) because it can be confusing that the example itself does not run.