### PR TITLE
Prevent null value on quit param

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -202,9 +202,10 @@ class UnityWidgetController {
     return null;
   }
 
-  /// quit method quits unity player. Note that this kills the current flutter process, thus quiting the app
+  /// Quits unity player. Note that this kills the current flutter process, thus quiting the app
   /// It optionally takes in [silent] which is a WIP to mitigate killing the flutter process
-  Future<void> quit({bool silent}) {
+  Future<void> quit({@required bool silent}) {
+    assert(silent != null);
     if (!_unityWidgetState.widget.enablePlaceholder) {
       return _unityViewFlutterPlatform.quitPlayer(
           unityId: unityId, silent: silent);


### PR DESCRIPTION
If the user doesn't provide a `silent` value to the `quit` method, an error is thrown (booleans cannot be null).

This changes prevents that value being null by marking it as a required param and asserting if null.