### PR TITLE
Fix for unityDidUnload callback not firing

### DIFF
--- a/ios/Classes/UnityPlayerUtils.swift
+++ b/ios/Classes/UnityPlayerUtils.swift
@@ -152,8 +152,9 @@ var sharedApplication: UIApplication?
             self.ufw?.unregisterFrameworkListener(self)
         }
     }
-    
-    private func unityDidUnload(notification: Notification?) {
+
+    @objc
+    public func unityDidUnload(_ notification: Notification!) {
         unregisterUnityListener()
         self.ufw?.unregisterFrameworkListener(self)
         self.ufw = nil
@@ -220,10 +221,6 @@ var sharedApplication: UIApplication?
     // Unoad unity player
     func unload() {
         self.ufw?.unloadApplication()
-        unregisterUnityListener()
-        self.ufw = nil
-        self._isUnityReady = false
-        self._isUnityLoaded = false
     }
 
     func isUnityLoaded() -> Bool {


### PR DESCRIPTION
Made the unityDidUnload callback available to obj-c and conform to the expected swift signature, so it could be called by UnityFramework. Removed state handling from unload method as it is now handled in the callback.