### PR TITLE
Add texture view workaround for android

### DIFF
--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityPlayerUtils.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityPlayerUtils.kt
@@ -2,6 +2,7 @@ package com.xraph.plugin.flutter_unity_widget
 
 import android.app.Activity
 import android.graphics.PixelFormat
+import android.graphics.SurfaceTexture
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -9,6 +10,8 @@ import android.util.Log
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.WindowManager
+import android.view.Surface
+import android.view.TextureView
 import com.unity3d.player.IUnityPlayerLifecycleEvents
 import com.unity3d.player.UnityPlayer
 import java.util.concurrent.CopyOnWriteArraySet
@@ -43,6 +46,27 @@ class UnityPlayerUtils {
                     if (!reInitialize) {
                         activity.window.setFormat(PixelFormat.RGBA_8888)
                         unityPlayer = UnityPlayer(activity, ule)
+
+                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                            val view = TextureView(activity)
+                            view.isOpaque = false
+                            view.surfaceTextureListener = object: TextureView.SurfaceTextureListener {
+                                override fun onSurfaceTextureAvailable(surface: SurfaceTexture,  width: Int, height: Int) {
+                                    unityPlayer!!.displayChanged(0, Surface(surface))
+                                }
+
+                                override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean {
+                                    return true
+                                }
+
+                                override fun onSurfaceTextureSizeChanged(surface: SurfaceTexture , width: Int, height: Int) {
+                                }
+
+                                override fun onSurfaceTextureUpdated(surface: SurfaceTexture) {
+                                }
+                            }
+                            unityPlayer!!.addViewToPlayer(view, true)
+                        }
                     }
 
                     try {


### PR DESCRIPTION
This branch will allow all supported android devices to render an unobstructed unity flutter widget view. This is done by calling `UnityPlayer::addViewToPlayer()` to swap the built in `SurfaceView` with a `TextureView`. Only android devices older than SDK version 26 (Oreo) will have this change made at runtime.

The code in this branch is based on comments from this ticket: https://github.com/juicycleff/flutter-unity-view-widget/issues/190