### PR TITLE
Fix: (Android) issues-429-hide-status-bar

### DIFF
--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityPlayerUtils.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityPlayerUtils.kt
@@ -64,9 +64,6 @@ class UnityPlayerUtils {
                         if (!options.fullscreenEnabled) {
                             activity.window.addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN)
                             activity.window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
-                            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
-                                activity.window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
-                            }
                         }
                     }
 


### PR DESCRIPTION
## Fix bug
- [issues-429: Hide status bar](https://github.com/juicycleff/flutter-unity-view-widget/issues/429)
- Relate Pull request  before kotlin version: [PR-14: Remove java and UnityPlayer changes to the windowmanager so it can be fully handled by Flutter](https://github.com/juicycleff/flutter-unity-view-widget/pull/14)
