### PR TITLE
fix: borderRadius and clipper can't be both null

### DIFF
--- a/lib/src/unity_view.dart
+++ b/lib/src/unity_view.dart
@@ -31,7 +31,7 @@ class UnityWidget extends StatefulWidget {
   final Widget? placeholder;
 
   /// Border radius
-  final BorderRadius? borderRadius;
+  final BorderRadius borderRadius;
 
   UnityWidget({
     Key? key,
@@ -45,7 +45,7 @@ class UnityWidget extends StatefulWidget {
     this.useAndroidView = false,
     this.onUnitySceneLoaded,
     this.uiLevel = 1,
-    this.borderRadius,
+    this.borderRadius = BorderRadius.zero,
   });
 
   @override


### PR DESCRIPTION
In `ClipRRect` constructor, `borderRadius` and `clipper` are asserted
that they shouldn't be null simultaneously. When `clipper` is not used
`borderRadius` can't has null value. The solution is to provide it a
default one.

If this issue not fixed, calling without `borderRadius` parameter will
encounter failed assertion. `assert(borderRadius != null || clipper !=
null)`

References

* https://api.flutter.dev/flutter/widgets/ClipRRect/ClipRRect.html