### PR TITLE
fix FLTUnityWidgetController.swift | add changelog | bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.3
+
+* Fixed iOS Run/Build errors: [471](https://github.com/juicycleff/flutter-unity-view-widget/issues/471)
+
 ## 4.2.2
 
 * Added support for border radius

--- a/ios/Classes/FLTUnityWidgetController.swift
+++ b/ios/Classes/FLTUnityWidgetController.swift
@@ -21,12 +21,13 @@ class FLTUnityWidgetController: NSObject, FLTUnityOptionsSink, FlutterPlatformVi
         arguments args: Any?,
         registrar: NSObjectProtocol & FlutterPluginRegistrar
     ) {
-        let curUILevel = args["uiLevel"] as? Int64 ?? 1;
-        self.setUILevel(level: curUILevel)
+        let dict = args as? Dictionary<String, Any>;
+        let curUILevel = dict?["uiLevel"] as? Int64 ?? 1;
         
         self.fltUnityView = FLTUnityView(frame: frame)
         super.init()
-        
+        self.setUILevel(level: curUILevel)
+
         self.viewId = viewId
         
         let channelName = String(format: "plugin.xraph.com/unity_view_%lld", viewId)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_unity_widget
 description: Flutter Unity 3D widget for embedding Unity game scenes in flutter. This library now supports Unity as a Library.
-version: 4.2.2
+version: 4.2.3
 #authors:
 #  - Rex Raphael <rex.raphael@outlook.com>
 #  - Thomas Stockx <thomas@stockxit.com>


### PR DESCRIPTION
@juicycleff 

I fixed the current error appearing for iOS Run and Builds.

Fixes: https://github.com/juicycleff/flutter-unity-view-widget/issues/471

It's publishable.

I will open another PR for the Android documentation due to NDK settings