### PR TITLE
fix : [Android] Double touch issue

### DIFF
--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityView.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityView.kt
@@ -32,11 +32,7 @@ class UnityView(context: Context) : FrameLayout(context) {
     }
 
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
-        if (player != null) {
-            ev.source = InputDevice.SOURCE_TOUCHSCREEN
-            player!!.injectEvent(ev)
-        }
-        return super.dispatchTouchEvent(ev)
+        return player?.dispatchTouchEvent(ev) ?: true
     }
 
     // Pass any events not handled by (unfocused) views straight to UnityPlayer


### PR DESCRIPTION
This PR will fix #421 
A touch duplicated by inject a touch event to Unity player.
Tested on example project. (rotate/touch a cube)