### PR TITLE
fix  fullscreenEnabled not effective

### DIFF
--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetController.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetController.kt
@@ -57,6 +57,7 @@ class FlutterUnityWidgetController(
 
         // set options
         this.options = options
+        setFullscreenEnabled(options.fullscreenEnabled)
 
         // setup method channel
         methodChannel = MethodChannel(binaryMessenger, "plugin.xraph.com/unity_view_$id")


### PR DESCRIPTION
in flutter set fullscreen:true Did not take effect， Because UnityPlayerUtils no use FlutterUnityWidgetController options, add setFullscreenEnabled function is useful，it is set UnityPlayerUtils options