### PR TITLE
fix: Hide status bar on fullscreen android

### DIFF
--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityPlayerUtils.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityPlayerUtils.kt
@@ -64,6 +64,7 @@ class UnityPlayerUtils {
                         if (!options.fullscreenEnabled) {
                             activity.window.addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN)
                             activity.window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+                            activity.window.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
                         }
                     }
 


### PR DESCRIPTION
This solve part of the bug when using version 4.2.2+ cf screens.

![image](https://user-images.githubusercontent.com/25187882/147384962-7334e0be-ea7c-4814-9821-179c27e3e19d.png)
Without fullscreen enabled: with a scaffold (or SafeArea) there is extra space between the AppBar and status bar.

![image](https://user-images.githubusercontent.com/25187882/147385070-6b61b271-60b7-4d56-bd1b-afd0dbd509e5.png)
With fullscreen enabled: status bar is not displayed

I'm not confortable enougth with android to fix the full bug but this is enougth in my case.