### PR TITLE
Fix: Set unity controller - Future already complete

### DIFF
--- a/lib/src/unity_widget.dart
+++ b/lib/src/unity_widget.dart
@@ -122,7 +122,7 @@ class UnityWidget extends StatefulWidget {
 class _UnityWidgetState extends State<UnityWidget> {
   late int _unityId = _nextUnityCreationId++;
 
-  final Completer<UnityWidgetController> _controller =
+  Completer<UnityWidgetController> _controller =
       Completer<UnityWidgetController>();
 
   @override
@@ -165,14 +165,16 @@ class _UnityWidgetState extends State<UnityWidget> {
 
   Future<void> _onPlatformViewCreated(int id) async {
     final controller = await UnityWidgetController.init(id, this);
+    _controller = Completer<UnityWidgetController>();
     _controller.complete(controller);
     final UnityCreatedCallback? onUnityCreated = widget.onUnityCreated;
 
     if (Platform.isAndroid) {
       await controller.pause();
       Future.delayed(
-        Duration(milliseconds: 100),
+        Duration(milliseconds: 200),
         () async {
+          log('** flutter unity controller resume **');
           await controller.resume();
         },
       );

--- a/lib/src/unity_widget.dart
+++ b/lib/src/unity_widget.dart
@@ -172,9 +172,8 @@ class _UnityWidgetState extends State<UnityWidget> {
     if (Platform.isAndroid) {
       await controller.pause();
       Future.delayed(
-        Duration(milliseconds: 200),
+        Duration(milliseconds: 100),
         () async {
-          log('** flutter unity controller resume **');
           await controller.resume();
         },
       );


### PR DESCRIPTION
## Description
When I switch enablePlaceholder `true` and `false`. The _onPlatformViewCreated function caught exception. This is the debug and error message
<img width="902" alt="Screen Shot 2022-02-16 at 11 40 13" src="https://user-images.githubusercontent.com/9074095/154200089-06c25213-bf49-4709-8e91-61f221c03a7e.png">


<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
