### PR TITLE
Fix: weird ios build target issue on non-osx machines, fixes #485

### DIFF
--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/XCodePostBuild.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/XCodePostBuild.cs
@@ -45,16 +45,13 @@ public static class XcodePostBuild
     [PostProcessBuild]
     public static void OnPostBuild(BuildTarget target, string pathToBuiltProject)
     {
-        if (target != BuildTarget.iOS)
-        {
-            return;
-        }
-
+#if UNITY_IOS
         PatchUnityNativeCode(pathToBuiltProject);
 
         UpdateUnityProjectFiles(pathToBuiltProject);
 
         UpdateBuildSettings(pathToBuiltProject);
+#endif
     }
 
     /// <summary>


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Ok this fix/the problem is really weird and I still haven't completely understood what goes wrong (I'm guessing some internal Unity bugs)
 
For some reason sometimes(?) `XcodePostBuild.OnPostBuild` gets the wrong target when building on non-osx machines, and thus because of
`target != BuildTarget.iOS` the script returns early although the target is iOS

The fix is to use `#ifdef UNITY_IOS` instead of `BuildTarget`
With this the problem described in a few issues was fixed (for us) apparently (current open issue #485)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
