### PR TITLE
Added missing call to completed in createPlayer to resolve issue #540

### DIFF
--- a/ios/Classes/UnityPlayerUtils.swift
+++ b/ios/Classes/UnityPlayerUtils.swift
@@ -132,6 +132,7 @@ var sharedApplication: UIApplication?
             
             self.initUnity()
             unity_warmed_up = true
+            completed(controller?.rootView)
             self.listenAppState()
         }
         


### PR DESCRIPTION
Added missing call to completed in createPlayer to resolve issue #540 (Blank screen on initializing UnityWidget, iOS)
