### PR TITLE
[fix]: typo in MessageEvent -> method

### DIFF
--- a/lib/src/web/web_unity_widget_controller.dart
+++ b/lib/src/web/web_unity_widget_controller.dart
@@ -202,7 +202,7 @@ class WebUnityWidgetController extends UnityWidgetController {
         'unityFlutterBiding',
         data: json.encode({
           "gameObject": gameObject,
-          "method": methodName,
+          "methodName": methodName,
           "message": message,
         }),
       );


### PR DESCRIPTION
## Description

There's a typo in `messageUnity ` why message were never received by Unity in index.html

`method` should be named `methodName` regarding to generated index.html for UnityLibrary for Web.

<img width="829" alt="Bildschirmfoto 2022-06-11 um 03 55 50" src="https://user-images.githubusercontent.com/18512224/173168246-2cdf9f3a-230e-4108-be4f-705d5c691fdd.png">

This PR fixes this.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
