### PR TITLE
[fix]: OnUnityCreated for web

### DIFF
--- a/lib/src/web/unity_widget.dart
+++ b/lib/src/web/unity_widget.dart
@@ -117,9 +117,7 @@ class _UnityWidgetState extends State<UnityWidget> {
 
     return WebUnityWidgetView(
       unitySrcUrl: widget.webUrl ?? '',
-      onWebViewCreated: (_) {
-        _onPlatformViewCreated();
-      },
+      onWebViewCreated: _onPlatformViewCreated,
       unityOptions: unityOptions,
     );
   }

--- a/lib/src/web/web_unity_widget_view.dart
+++ b/lib/src/web/web_unity_widget_view.dart
@@ -12,7 +12,7 @@ class WebUnityWidgetView extends StatefulWidget {
   /// Unity export sorce path, can be hosted or local
   final String unitySrcUrl;
   final Map<String, dynamic> unityOptions;
-  final Function(WebViewXController controller) onWebViewCreated;
+  final void Function() onWebViewCreated;
 
   @override
   State<WebUnityWidgetView> createState() => _WebUnityWidgetViewState();
@@ -22,6 +22,7 @@ class _WebUnityWidgetViewState extends State<WebUnityWidgetView> {
   @override
   void initState() {
     super.initState();
+    widget.onWebViewCreated();
   }
 
   @override
@@ -35,7 +36,7 @@ class _WebUnityWidgetViewState extends State<WebUnityWidgetView> {
       initialContent: widget.unitySrcUrl,
       initialSourceType: SourceType.url,
       javascriptMode: JavascriptMode.unrestricted,
-      onWebViewCreated: widget.onWebViewCreated,
+      onWebViewCreated: (_) {},
       height: MediaQuery.of(context).size.height,
       width: MediaQuery.of(context).size.width,
     );


### PR DESCRIPTION
## Description

`OnUnityCreated` never worked for Web.

This PR fixes this by start calling _onPlatformViewCreated, If first frame of WebView was created.

Otherwise -> Callback in WebViewX is never called!

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)