### PR TITLE
[fix]: missing web concrete implementations

### DIFF
--- a/lib/src/facade_controller.dart
+++ b/lib/src/facade_controller.dart
@@ -19,32 +19,32 @@ abstract class UnityWidgetController {
   /// Checks to see if unity player is ready to be used
   /// Returns `true` if unity player is ready.
   Future<bool?>? isReady() {
-    throw UnimplementedError('init() has not been implemented.');
+    throw UnimplementedError('isReady() has not been implemented.');
   }
 
   /// Get the current pause state of the unity player
   /// Returns `true` if unity player is paused.
   Future<bool?>? isPaused() {
-    throw UnimplementedError('init() has not been implemented.');
+    throw UnimplementedError('isPaused() has not been implemented.');
   }
 
   /// Get the current load state of the unity player
   /// Returns `true` if unity player is loaded.
   Future<bool?>? isLoaded() {
-    throw UnimplementedError('init() has not been implemented.');
+    throw UnimplementedError('isLoaded() has not been implemented.');
   }
 
   /// Helper method to know if Unity has been put in background mode (WIP) unstable
   /// Returns `true` if unity player is in background.
   Future<bool?>? inBackground() {
-    throw UnimplementedError('init() has not been implemented.');
+    throw UnimplementedError('inBackground() has not been implemented.');
   }
 
   /// Creates a unity player if it's not already created. Please only call this if unity is not ready,
   /// or is in unloaded state. Use [isLoaded] to check.
   /// Returns `true` if unity player was created succesfully.
   Future<bool?>? create() {
-    throw UnimplementedError('init() has not been implemented.');
+    throw UnimplementedError('create() has not been implemented.');
   }
 
   /// Post message to unity from flutter. This method takes in a string [message].
@@ -55,7 +55,7 @@ abstract class UnityWidgetController {
   /// postMessage("GameManager", "openScene", "ThirdScene")
   /// ```
   Future<void>? postMessage(String gameObject, methodName, message) {
-    throw UnimplementedError('init() has not been implemented.');
+    throw UnimplementedError('postMessage() has not been implemented.');
   }
 
   /// Post message to unity from flutter. This method takes in a Json or map structure as the [message].
@@ -67,37 +67,37 @@ abstract class UnityWidgetController {
   /// ```
   Future<void>? postJsonMessage(
       String gameObject, String methodName, Map<String, dynamic> message) {
-    throw UnimplementedError('init() has not been implemented.');
+    throw UnimplementedError('postJsonMessage() has not been implemented.');
   }
 
   /// Pause the unity in-game player with this method
   Future<void>? pause() {
-    throw UnimplementedError('init() has not been implemented.');
+    throw UnimplementedError('pause() has not been implemented.');
   }
 
   /// Resume the unity in-game player with this method idf it is in a paused state
   Future<void>? resume() {
-    throw UnimplementedError('init() has not been implemented.');
+    throw UnimplementedError('resume() has not been implemented.');
   }
 
   /// Sometimes you want to open unity in it's own process and openInNativeProcess does just that.
   /// It works for Android and iOS is WIP
   Future<void>? openInNativeProcess() {
-    throw UnimplementedError('init() has not been implemented.');
+    throw UnimplementedError('openInNativeProcess() has not been implemented.');
   }
 
   /// Unloads unity player from th current process (Works on Android only for now)
   /// iOS is WIP. For more information please read [Unity Docs](https://docs.unity3d.com/2020.2/Documentation/Manual/UnityasaLibrary.html)
   Future<void>? unload() {
-    throw UnimplementedError('init() has not been implemented.');
+    throw UnimplementedError('unload() has not been implemented.');
   }
 
   /// Quits unity player. Note that this kills the current flutter process, thus quiting the app
   Future<void>? quit() {
-    throw UnimplementedError('init() has not been implemented.');
+    throw UnimplementedError('quit() has not been implemented.');
   }
 
   void dispose() {
-    throw UnimplementedError('init() has not been implemented.');
+    throw UnimplementedError('dispose() has not been implemented.');
   }
 }

--- a/lib/src/web/unity_widget.dart
+++ b/lib/src/web/unity_widget.dart
@@ -125,7 +125,7 @@ class _UnityWidgetState extends State<UnityWidget> {
   }
 
   Future<void> _onPlatformViewCreated() async {
-    final controller = await WebUnityWidgetController(this);
+    final controller = await WebUnityWidgetController.init(0, this);
     _controller = controller;
     widget.onUnityCreated(controller);
 

--- a/lib/src/web/web_unity_widget_controller.dart
+++ b/lib/src/web/web_unity_widget_controller.dart
@@ -51,7 +51,7 @@ class WebUnityWidgetController extends UnityWidgetController {
   // Returns a filtered view of the events in the _controller, by unityId.
   Stream<UnityEvent> get _events => _unityStreamController.stream;
 
-  WebUnityWidgetController(this._unityWidgetState) {
+  WebUnityWidgetController._(this._unityWidgetState) {
     _channel = ensureChannelInitialized();
     _connectStreams();
     _registerEvents();
@@ -69,12 +69,12 @@ class WebUnityWidgetController extends UnityWidgetController {
   // /// Initialize [UnityWidgetController] with [id]
   // /// Mainly for internal use when instantiating a [UnityWidgetController] passed
   // /// in [UnityWidget.onUnityCreated] callback.
-  // static Future<WebUnityWidgetController> init(
-  //     int id, _UnityWidgetState unityWidgetState) async {
-  //   return WebUnityWidgetController._(
-  //     unityWidgetState,
-  //   );
-  // }
+  static Future<WebUnityWidgetController> init(
+      int id, WebUnityWidgetState unityWidgetState) async {
+    return WebUnityWidgetController._(
+      unityWidgetState,
+    );
+  }
 
   /// Method required for web initialization
   static void registerWith(Registrar registrar) {

--- a/lib/src/web/web_unity_widget_controller.dart
+++ b/lib/src/web/web_unity_widget_controller.dart
@@ -211,26 +211,39 @@ class WebUnityWidgetController extends UnityWidgetController {
   }
 
   @override
+  Future<void>? postMessage(
+    String gameObject,
+    dynamic methodName,
+    dynamic message,
+  ) async {
+    messageUnity(
+      gameObject: gameObject,
+      methodName: methodName,
+      message: message,
+    );
+  }
+
+  @override
   Future<void> postJsonMessage(
     String gameObject,
     String methodName,
     Map<String, dynamic> message,
   ) async {
-    await channel.invokeMethod('unity#postMessage', <String, dynamic>{
-      'gameObject': gameObject,
-      'methodName': methodName,
-      'message': json.encode(message),
-    });
+    messageUnity(
+      gameObject: gameObject,
+      methodName: methodName,
+      message: json.encode(message),
+    );
   }
 
   @override
   Future<void> pause() async {
-    await channel.invokeMethod('unity#pausePlayer');
+    callUnityFn(fnName: 'pause');
   }
 
   @override
   Future<void> resume() async {
-    await channel.invokeMethod('unity#resumePlayer');
+    callUnityFn(fnName: 'resume');
   }
 
   @override
@@ -240,12 +253,12 @@ class WebUnityWidgetController extends UnityWidgetController {
 
   @override
   Future<void> unload() async {
-    await channel.invokeMethod('unity#unloadPlayer');
+    callUnityFn(fnName: 'unload');
   }
 
   @override
   Future<void> quit() async {
-    await channel.invokeMethod('unity#quitPlayer');
+    callUnityFn(fnName: 'quit');
   }
 
   /// cancel the subscriptions when dispose called


### PR DESCRIPTION
## Description

Several concrete implementations were missing for Web to send messages (`postMessage`) and to initialize properly (`init`).

1. This PR fixes these errors
2. This PR refactored the calls to Unity Web by calling messageUnity for example directly.

After investigating actual Federated-Plugin implementations in the Flutter-Community, the MethodChannels aren't working and not best practise for Federated-Plugins or Plugins like these, where you got an Interface-Class.

This messes with invokeMethod and **invokeMethod wasn't even working for web**.

But I just left the `setMethodCallHandler` for any reason you need it.

But now Web is finally sending and receiving messages with this PR.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
