### PR TITLE
Use legacy iOSBuildConfigType for Unity versions < 2021.

### DIFF
--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -336,7 +336,11 @@ body { padding: 0; margin: 0; overflow: hidden; }
             if (Directory.Exists(path))
                 Directory.Delete(path, true);
 
+#if (UNITY_2021_1_OR_NEWER)
             EditorUserBuildSettings.iOSXcodeBuildConfig = XcodeBuildConfig.Release;
+#else
+            EditorUserBuildSettings.iOSBuildConfigType = iOSBuildType.Release;
+#endif
 
             var playerOptions = new BuildPlayerOptions
             {


### PR DESCRIPTION
Even though the package version has jumped to Unity 2022.x, this project still works fine with older versions like Unity 2019.

There is a small compile error when importing the unitypackage in Unity 2019 or 2020.
Unity 2021 and 2022 use ` EditorUserBuildSettings.iOSXcodeBuildConfig`, while Unity 2019 and 2020 use `EditorUserBuildSettings.iOSBuildConfigType`

A conditional allows both to work.
```
#if (UNITY_2021_1_OR_NEWER)
            EditorUserBuildSettings.iOSXcodeBuildConfig = XcodeBuildConfig.Release;
#else
            EditorUserBuildSettings.iOSBuildConfigType = iOSBuildType.Release;
#endif
```
