### PR TITLE
Web: fix the issue when the flutter app is loaded not from base path

### DIFF
--- a/lib/src/web/web_unity_widget_view.dart
+++ b/lib/src/web/web_unity_widget_view.dart
@@ -29,9 +29,10 @@ class _WebUnityWidgetViewState extends State<WebUnityWidgetView> {
 
   @override
   Widget build(BuildContext context) {
+    var path = Uri.base.path == '/' ? '' : Uri.base.path;
     var pathConnector = Uri.base.path.endsWith('/') ? '' : '/';
     return WebViewX(
-      initialContent: '${Uri.base.origin}${Uri.base.path == '/' ? '' : Uri.base.path}${pathConnector}UnityLibrary/index.html',
+      initialContent: '${Uri.base.origin}${path}${pathConnector}UnityLibrary/index.html',
       initialSourceType: SourceType.url,
       javascriptMode: JavascriptMode.unrestricted,
       onWebViewCreated: (_) {},

--- a/lib/src/web/web_unity_widget_view.dart
+++ b/lib/src/web/web_unity_widget_view.dart
@@ -29,8 +29,9 @@ class _WebUnityWidgetViewState extends State<WebUnityWidgetView> {
 
   @override
   Widget build(BuildContext context) {
+    var pathConnector = Uri.base.path.endsWith('/') ? '' : '/';
     return WebViewX(
-      initialContent: '${Uri.base.origin}${Uri.base.path == '/' ? '' : Uri.base.path}/UnityLibrary/index.html',
+      initialContent: '${Uri.base.origin}${Uri.base.path == '/' ? '' : Uri.base.path}${pathConnector}UnityLibrary/index.html',
       initialSourceType: SourceType.url,
       javascriptMode: JavascriptMode.unrestricted,
       onWebViewCreated: (_) {},

--- a/lib/src/web/web_unity_widget_view.dart
+++ b/lib/src/web/web_unity_widget_view.dart
@@ -31,6 +31,10 @@ class _WebUnityWidgetViewState extends State<WebUnityWidgetView> {
   Widget build(BuildContext context) {
     var path = Uri.base.path == '/' ? '' : Uri.base.path;
     var pathConnector = Uri.base.path.endsWith('/') ? '' : '/';
+    print('Uri.base.origin ${Uri.base.origin}');
+    print('Uri.base.path ${Uri.base.path}');
+    print('path $path');
+    print('pathConnector $pathConnector');
     return WebViewX(
       initialContent: '${Uri.base.origin}${path}${pathConnector}UnityLibrary/index.html',
       initialSourceType: SourceType.url,

--- a/lib/src/web/web_unity_widget_view.dart
+++ b/lib/src/web/web_unity_widget_view.dart
@@ -30,7 +30,7 @@ class _WebUnityWidgetViewState extends State<WebUnityWidgetView> {
   @override
   Widget build(BuildContext context) {
     return WebViewX(
-      initialContent: '${Uri.base.origin}/UnityLibrary/index.html',
+      initialContent: '${Uri.base.origin}${Uri.base.path == '/' ? '' : Uri.base.path}/UnityLibrary/index.html',
       initialSourceType: SourceType.url,
       javascriptMode: JavascriptMode.unrestricted,
       onWebViewCreated: (_) {},


### PR DESCRIPTION
In some cases flutter web app will be hosted not at a root level. This fix is detecting that and adding to the Unity's index.html path.