### PR TITLE
Fixed Unity not receiving lifecycle events from iOS

### DIFF
--- a/ios/Classes/UnityPlayerUtils.swift
+++ b/ios/Classes/UnityPlayerUtils.swift
@@ -170,7 +170,7 @@ var sharedApplication: UIApplication?
             return
         }
 
-        let unityAppController = self.ufw?.appController as? UnityAppController
+        let unityAppController = self.ufw?.appController() as? UnityAppController
         let application = UIApplication.shared
 
         if notification?.name == UIApplication.willResignActiveNotification {
@@ -199,13 +199,10 @@ var sharedApplication: UIApplication?
             UIApplication.willEnterForegroundNotification,
             UIApplication.didReceiveMemoryWarningNotification
         ] {
-            guard let name = name as? String else {
-                continue
-            }
             NotificationCenter.default.addObserver(
                 self,
                 selector: #selector(self.handleAppStateDidChange),
-                name: NSNotification.Name(name),
+                name: name,
                 object: nil)
         }
     }


### PR DESCRIPTION
## Description

There are some casting bugs preventing iOS lifecycle events (didBecomeActive, wilEnterForeground, etc) from reaching unity. This causes two issues:
- OnApplicationPaused() callbacks don't fire in unity
- When the app is backgrounded, Unity does not pause, causing high cpu/battery usage while backgrounded

This patch fixes these casting bugs.

Specifically:
- line 173 fixes an attempted cast of the `.appController()` method itself to the object the method returns. Since the method isn't actually called, nothing is returned and the casting fails.
- lines 202-208 fix an attempted cast of `NSNotification.Name` (an enum) to a `String`. This cast fails and so the code path wiring up the observer is skipped.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
