### PR TITLE
Remove Android's white background color.

### DIFF
--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetController.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetController.kt
@@ -57,7 +57,7 @@ class FlutterUnityWidgetController(
         if (context != null) tempContext = context
         // set layout view
         view = FrameLayout(tempContext)
-        view.setBackgroundColor(Color.WHITE)
+        view.setBackgroundColor(Color.TRANSPARENT)
 
         // setup method channel
         methodChannel = MethodChannel(binaryMessenger, "plugin.xraph.com/unity_view_$id")


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This removes the white background set in Kotlin, which allows us to experiment with a transparent UnityWidget.
iOS doesn't need any change as this already works.

This should not affect most users, because to see any change you need to both manually configure Unity and adjust the android theme.

See this example of a video widget playing behind Unity to get an idea of the possible results.  
(The video is started on a small delay to show the black flash, which is a flutter bug with AndroidView.)

https://user-images.githubusercontent.com/11444698/203645680-dcb7812d-e0c6-4373-89f3-79d72bf6bc68.mp4


See [https://github.com/juicycleff/flutter-unity-view-widget/issues/190#issuecomment-1296383215](https://github.com/juicycleff/flutter-unity-view-widget/issues/190#issuecomment-1296383215) for more details.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
