### PR TITLE
[feat global_unity_controller] Update examples to null safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,40 +434,41 @@ Unable to find a matching variant of project :unityLibrary:
 
 ```dart
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 
 void main() {
-  runApp(MaterialApp(
-    home: UnityDemoScreen()
-  ));
+  runApp(
+    const MaterialApp(
+      home: UnityDemoScreen(),
+    ),
+  );
 }
 
 class UnityDemoScreen extends StatefulWidget {
-
-  UnityDemoScreen({Key key}) : super(key: key);
+  const UnityDemoScreen({Key? key}) : super(key: key);
 
   @override
-  _UnityDemoScreenState createState() => _UnityDemoScreenState();
+  State<UnityDemoScreen> createState() => _UnityDemoScreenState();
 }
 
-class _UnityDemoScreenState extends State<UnityDemoScreen>{
+class _UnityDemoScreenState extends State<UnityDemoScreen> {
   static final GlobalKey<ScaffoldState> _scaffoldKey =
       GlobalKey<ScaffoldState>();
-  UnityWidgetController _unityWidgetController;
+  UnityWidgetController? _unityWidgetController;
 
+  @override
   Widget build(BuildContext context) {
-
     return Scaffold(
       key: _scaffoldKey,
       body: SafeArea(
         bottom: false,
         child: WillPopScope(
-          onWillPop: () {
+          onWillPop: () async {
             // Pop the category page if Android back button is pressed.
+            return true;
           },
           child: Container(
-            color: colorYellow,
+            color: Colors.yellow,
             child: UnityWidget(
               onUnityCreated: onUnityCreated,
             ),
@@ -479,9 +480,10 @@ class _UnityDemoScreenState extends State<UnityDemoScreen>{
 
   // Callback that connects the created controller to the unity controller
   void onUnityCreated(controller) {
-    this._unityWidgetController = controller;
+    _unityWidgetController = controller;
   }
 }
+
 ```
 <br />
 
@@ -491,17 +493,19 @@ class _UnityDemoScreenState extends State<UnityDemoScreen>{
 import 'package:flutter/material.dart';
 import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 
-void main() => runApp(MyApp());
+void main() => runApp(const MyApp());
 
 class MyApp extends StatefulWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
-  _MyAppState createState() => _MyAppState();
+  State<MyApp> createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
   static final GlobalKey<ScaffoldState> _scaffoldKey =
       GlobalKey<ScaffoldState>();
-  UnityWidgetController _unityWidgetController;
+  UnityWidgetController? _unityWidgetController;
   double _sliderValue = 0.0;
 
   @override
@@ -526,10 +530,10 @@ class _MyAppState extends State<MyApp> {
           child: Stack(
             children: <Widget>[
               UnityWidget(
-                  onUnityCreated: onUnityCreated,
-                  onUnityMessage: onUnityMessage,
-                  onUnitySceneLoaded: onUnitySceneLoaded,
-                  fullscreen: false,
+                onUnityCreated: onUnityCreated,
+                onUnityMessage: onUnityMessage,
+                onUnitySceneLoaded: onUnitySceneLoaded,
+                fullscreen: false,
               ),
               Positioned(
                 bottom: 20,
@@ -539,8 +543,8 @@ class _MyAppState extends State<MyApp> {
                   elevation: 10,
                   child: Column(
                     children: <Widget>[
-                      Padding(
-                        padding: const EdgeInsets.only(top: 20),
+                      const Padding(
+                        padding: EdgeInsets.only(top: 20),
                         child: Text("Rotation speed:"),
                       ),
                       Slider(
@@ -567,7 +571,7 @@ class _MyAppState extends State<MyApp> {
 
   // Communcation from Flutter to Unity
   void setRotationSpeed(String speed) {
-    _unityWidgetController.postMessage(
+    _unityWidgetController?.postMessage(
       'Cube',
       'SetRotationSpeed',
       speed,
@@ -581,15 +585,17 @@ class _MyAppState extends State<MyApp> {
 
   // Callback that connects the created controller to the unity controller
   void onUnityCreated(controller) {
-    this._unityWidgetController = controller;
+    _unityWidgetController = controller;
   }
 
   // Communication from Unity when new scene is loaded to Flutter
-  void onUnitySceneLoaded(SceneLoaded sceneInfo) {
-    print('Received scene loaded from unity: ${sceneInfo.name}');
-    print('Received scene loaded from unity buildIndex: ${sceneInfo.buildIndex}');
+  void onUnitySceneLoaded(SceneLoaded? sceneInfo) {
+    if (sceneInfo != null) {
+      print('Received scene loaded from unity: ${sceneInfo.name}');
+      print(
+          'Received scene loaded from unity buildIndex: ${sceneInfo.buildIndex}');
+    }
   }
-
 }
 
 ```

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,10 +8,12 @@ import 'screens/loader_screen.dart';
 import 'screens/simple_screen.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
@@ -23,12 +25,12 @@ class MyApp extends StatelessWidget {
       ),
       initialRoute: '/',
       routes: {
-        '/': (context) => MenuScreen(),
-        '/simple': (context) => SimpleScreen(),
-        '/loader': (context) => LoaderScreen(),
-        '/orientation': (context) => OrientationScreen(),
-        '/api': (context) => ApiScreen(),
-        '/none': (context) => NoInteractionScreen(),
+        '/': (context) => const MenuScreen(),
+        '/simple': (context) => const SimpleScreen(),
+        '/loader': (context) => const LoaderScreen(),
+        '/orientation': (context) => const OrientationScreen(),
+        '/api': (context) => const ApiScreen(),
+        '/none': (context) => const NoInteractionScreen(),
       },
     );
   }

--- a/example/lib/menu_screen.dart
+++ b/example/lib/menu_screen.dart
@@ -1,48 +1,48 @@
 import 'package:flutter/material.dart';
 
 class MenuScreen extends StatefulWidget {
-  MenuScreen({Key? key}) : super(key: key);
+  const MenuScreen({Key? key}) : super(key: key);
 
   @override
-  _MenuScreenState createState() => _MenuScreenState();
+  State<MenuScreen> createState() => _MenuScreenState();
 }
 
 class _MenuScreenState extends State<MenuScreen> {
   bool enableAR = true;
 
   List<_MenuListItem> menus = [
-    new _MenuListItem(
+    _MenuListItem(
       description: 'Simple demonstration of unity flutter library',
       route: '/simple',
       title: 'Simple Unity Demo',
       enableAR: false,
     ),
-    new _MenuListItem(
+    _MenuListItem(
       description: 'No interaction of unity flutter library',
       route: '/none',
       title: 'No Interaction Unity Demo',
       enableAR: false,
     ),
-    new _MenuListItem(
+    _MenuListItem(
       description: 'Unity load and unload unity demo',
       route: '/loader',
       title: 'Safe mode Demo',
       enableAR: false,
     ),
-    new _MenuListItem(
+    _MenuListItem(
       description:
           'This example shows various native API exposed by the library',
       route: '/api',
       title: 'Native exposed API demo',
       enableAR: false,
     ),
-    new _MenuListItem(
+    _MenuListItem(
       title: 'Test Orientation',
       route: '/orientation',
       description: 'test orientation change',
       enableAR: false,
     ),
-    new _MenuListItem(
+    _MenuListItem(
       description: 'Unity native activity demo',
       route: '/activity',
       title: 'Native Activity Demo ',
@@ -54,11 +54,11 @@ class _MenuScreenState extends State<MenuScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Menu List'),
+        title: const Text('Menu List'),
         actions: [
           Row(
             children: [
-              Text("Enable AR"),
+              const Text("Enable AR"),
               Checkbox(
                 value: enableAR,
                 onChanged: (changed) {

--- a/example/lib/menu_screen.dart
+++ b/example/lib/menu_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class MenuScreen extends StatefulWidget {
-  MenuScreen({Key key}) : super(key: key);
+  MenuScreen({Key? key}) : super(key: key);
 
   @override
   _MenuScreenState createState() => _MenuScreenState();
@@ -62,9 +62,11 @@ class _MenuScreenState extends State<MenuScreen> {
               Checkbox(
                 value: enableAR,
                 onChanged: (changed) {
-                  setState(() {
-                    enableAR = changed;
-                  });
+                  if (changed != null) {
+                    setState(() {
+                      enableAR = changed;
+                    });
+                  }
                 },
               ),
             ],
@@ -97,5 +99,10 @@ class _MenuListItem {
   final String route;
   final bool enableAR;
 
-  _MenuListItem({this.title, this.description, this.route, this.enableAR});
+  _MenuListItem({
+    required this.title,
+    required this.description,
+    required this.route,
+    required this.enableAR,
+  });
 }

--- a/example/lib/screens/api_screen.dart
+++ b/example/lib/screens/api_screen.dart
@@ -1,12 +1,14 @@
+// ignore_for_file: avoid_print
+
 import 'package:flutter/material.dart';
 import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 class ApiScreen extends StatefulWidget {
-  ApiScreen({Key? key}) : super(key: key);
+  const ApiScreen({Key? key}) : super(key: key);
 
   @override
-  _ApiScreenState createState() => _ApiScreenState();
+  State<ApiScreen> createState() => _ApiScreenState();
 }
 
 class _ApiScreenState extends State<ApiScreen> {
@@ -28,7 +30,7 @@ class _ApiScreenState extends State<ApiScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('API Screen'),
+        title: const Text('API Screen'),
       ),
       body: Card(
         margin: const EdgeInsets.all(8),
@@ -38,14 +40,12 @@ class _ApiScreenState extends State<ApiScreen> {
         ),
         child: Stack(
           children: [
-            Container(
-              child: UnityWidget(
-                onUnityCreated: onUnityCreated,
-                onUnityMessage: onUnityMessage,
-                onUnitySceneLoaded: onUnitySceneLoaded,
-                fullscreen: true,
-                useAndroidViewSurface: false,
-              ),
+            UnityWidget(
+              onUnityCreated: onUnityCreated,
+              onUnityMessage: onUnityMessage,
+              onUnitySceneLoaded: onUnitySceneLoaded,
+              fullscreen: true,
+              useAndroidViewSurface: false,
             ),
             PointerInterceptor(
               child: Positioned(
@@ -57,8 +57,8 @@ class _ApiScreenState extends State<ApiScreen> {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: <Widget>[
-                      Padding(
-                        padding: const EdgeInsets.only(top: 20),
+                      const Padding(
+                        padding: EdgeInsets.only(top: 20),
                         child: Text("Rotation speed:"),
                       ),
                       Slider(
@@ -80,25 +80,25 @@ class _ApiScreenState extends State<ApiScreen> {
                               onPressed: () {
                                 FlutterUnityController.instance.quit();
                               },
-                              child: Text("Quit"),
+                              child: const Text("Quit"),
                             ),
                             MaterialButton(
                               onPressed: () {
                                 FlutterUnityController.instance.create();
                               },
-                              child: Text("Create"),
+                              child: const Text("Create"),
                             ),
                             MaterialButton(
                               onPressed: () {
                                 FlutterUnityController.instance.pause();
                               },
-                              child: Text("Pause"),
+                              child: const Text("Pause"),
                             ),
                             MaterialButton(
                               onPressed: () {
                                 FlutterUnityController.instance.resume();
                               },
-                              child: Text("Resume"),
+                              child: const Text("Resume"),
                             ),
                           ],
                         ),
@@ -112,19 +112,19 @@ class _ApiScreenState extends State<ApiScreen> {
                                 await FlutterUnityController.instance
                                     .openInNativeProcess();
                               },
-                              child: Text("Open Native"),
+                              child: const Text("Open Native"),
                             ),
                             MaterialButton(
                               onPressed: () {
                                 FlutterUnityController.instance.unload();
                               },
-                              child: Text("Unload"),
+                              child: const Text("Unload"),
                             ),
                             MaterialButton(
                               onPressed: () {
                                 FlutterUnityController.instance.quit();
                               },
-                              child: Text("Silent Quit"),
+                              child: const Text("Silent Quit"),
                             ),
                           ],
                         ),
@@ -163,6 +163,6 @@ class _ApiScreenState extends State<ApiScreen> {
 
   // Callback that connects the created controller to the unity controller
   void onUnityCreated(controller) {
-    // this._unityWidgetController = controller;
+    // _unityWidgetController = controller;
   }
 }

--- a/example/lib/screens/api_screen.dart
+++ b/example/lib/screens/api_screen.dart
@@ -3,14 +3,14 @@ import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 class ApiScreen extends StatefulWidget {
-  ApiScreen({Key key}) : super(key: key);
+  ApiScreen({Key? key}) : super(key: key);
 
   @override
   _ApiScreenState createState() => _ApiScreenState();
 }
 
 class _ApiScreenState extends State<ApiScreen> {
-  // UnityWidgetController _unityWidgetController;
+  // UnityWidgetController? _unityWidgetController;
   double _sliderValue = 0.0;
 
   @override
@@ -152,9 +152,13 @@ class _ApiScreenState extends State<ApiScreen> {
     print('Received message from unity: ${message.toString()}');
   }
 
-  void onUnitySceneLoaded(SceneLoaded scene) {
-    print('Received scene loaded from unity: ${scene.name}');
-    print('Received scene loaded from unity buildIndex: ${scene.buildIndex}');
+  void onUnitySceneLoaded(SceneLoaded? scene) {
+    if (scene != null) {
+      print('Received scene loaded from unity: ${scene.name}');
+      print('Received scene loaded from unity buildIndex: ${scene.buildIndex}');
+    } else {
+      print('Received scene loaded from unity: null');
+    }
   }
 
   // Callback that connects the created controller to the unity controller

--- a/example/lib/screens/loader_screen.dart
+++ b/example/lib/screens/loader_screen.dart
@@ -1,12 +1,14 @@
+// ignore_for_file: avoid_print
+
 import 'package:flutter/material.dart';
 import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 class LoaderScreen extends StatefulWidget {
-  LoaderScreen({Key? key}) : super(key: key);
+  const LoaderScreen({Key? key}) : super(key: key);
 
   @override
-  _LoaderScreenState createState() => _LoaderScreenState();
+  State<LoaderScreen> createState() => _LoaderScreenState();
 }
 
 class _LoaderScreenState extends State<LoaderScreen> {
@@ -22,7 +24,7 @@ class _LoaderScreenState extends State<LoaderScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Safe Mode Screen'),
+        title: const Text('Safe Mode Screen'),
       ),
       body: Card(
         margin: const EdgeInsets.all(8),
@@ -46,8 +48,8 @@ class _LoaderScreenState extends State<LoaderScreen> {
                   elevation: 10,
                   child: Column(
                     children: <Widget>[
-                      Padding(
-                        padding: const EdgeInsets.only(top: 20),
+                      const Padding(
+                        padding: EdgeInsets.only(top: 20),
                         child: Text("Rotation speed:"),
                       ),
                       Slider(
@@ -86,6 +88,6 @@ class _LoaderScreenState extends State<LoaderScreen> {
 
   // Callback that connects the created controller to the unity controller
   void onUnityCreated(controller) {
-    this._unityWidgetController = controller;
+    _unityWidgetController = controller;
   }
 }

--- a/example/lib/screens/loader_screen.dart
+++ b/example/lib/screens/loader_screen.dart
@@ -3,14 +3,14 @@ import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 class LoaderScreen extends StatefulWidget {
-  LoaderScreen({Key key}) : super(key: key);
+  LoaderScreen({Key? key}) : super(key: key);
 
   @override
   _LoaderScreenState createState() => _LoaderScreenState();
 }
 
 class _LoaderScreenState extends State<LoaderScreen> {
-  UnityWidgetController _unityWidgetController;
+  UnityWidgetController? _unityWidgetController;
   double _sliderValue = 0.0;
 
   @override
@@ -73,7 +73,7 @@ class _LoaderScreenState extends State<LoaderScreen> {
   }
 
   void setRotationSpeed(String speed) {
-    _unityWidgetController.postMessage(
+    _unityWidgetController?.postMessage(
       'Cube',
       'SetRotationSpeed',
       speed,

--- a/example/lib/screens/no_interaction_screen.dart
+++ b/example/lib/screens/no_interaction_screen.dart
@@ -3,10 +3,10 @@ import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 class NoInteractionScreen extends StatefulWidget {
-  NoInteractionScreen({Key? key}) : super(key: key);
+  const NoInteractionScreen({Key? key}) : super(key: key);
 
   @override
-  _NoInteractionScreenState createState() => _NoInteractionScreenState();
+  State<NoInteractionScreen> createState() => _NoInteractionScreenState();
 }
 
 class _NoInteractionScreenState extends State<NoInteractionScreen> {
@@ -31,7 +31,7 @@ class _NoInteractionScreenState extends State<NoInteractionScreen> {
     return Scaffold(
       key: _scaffoldKey,
       appBar: AppBar(
-        title: Text('No Interaction Screen'),
+        title: const Text('No Interaction Screen'),
       ),
       body: Card(
         margin: const EdgeInsets.all(8),
@@ -46,7 +46,7 @@ class _NoInteractionScreenState extends State<NoInteractionScreen> {
               onUnityMessage: onUnityMessage,
               onUnitySceneLoaded: onUnitySceneLoaded,
               useAndroidViewSurface: true,
-              borderRadius: BorderRadius.all(Radius.circular(70)),
+              borderRadius: const BorderRadius.all(Radius.circular(70)),
             ),
             PointerInterceptor(
               child: Positioned(
@@ -57,7 +57,7 @@ class _NoInteractionScreenState extends State<NoInteractionScreen> {
                   onPressed: () {
                     Navigator.of(context).pushNamed('/simple');
                   },
-                  child: Text('Switch Flutter Screen'),
+                  child: const Text('Switch Flutter Screen'),
                 ),
               ),
             ),
@@ -91,6 +91,6 @@ class _NoInteractionScreenState extends State<NoInteractionScreen> {
   // Callback that connects the created controller to the unity controller
   void _onUnityCreated(controller) {
     controller.resume();
-    this._unityWidgetController = controller;
+    _unityWidgetController = controller;
   }
 }

--- a/example/lib/screens/no_interaction_screen.dart
+++ b/example/lib/screens/no_interaction_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 class NoInteractionScreen extends StatefulWidget {
-  NoInteractionScreen({Key key}) : super(key: key);
+  NoInteractionScreen({Key? key}) : super(key: key);
 
   @override
   _NoInteractionScreenState createState() => _NoInteractionScreenState();
@@ -13,7 +13,7 @@ class _NoInteractionScreenState extends State<NoInteractionScreen> {
   static final GlobalKey<ScaffoldState> _scaffoldKey =
       GlobalKey<ScaffoldState>();
 
-  UnityWidgetController _unityWidgetController;
+  UnityWidgetController? _unityWidgetController;
 
   @override
   void initState() {
@@ -22,7 +22,7 @@ class _NoInteractionScreenState extends State<NoInteractionScreen> {
 
   @override
   void dispose() {
-    _unityWidgetController.dispose();
+    _unityWidgetController?.dispose();
     super.dispose();
   }
 
@@ -68,7 +68,7 @@ class _NoInteractionScreenState extends State<NoInteractionScreen> {
   }
 
   void setRotationSpeed(String speed) {
-    _unityWidgetController.postMessage(
+    _unityWidgetController?.postMessage(
       'Cube',
       'SetRotationSpeed',
       speed,
@@ -79,9 +79,13 @@ class _NoInteractionScreenState extends State<NoInteractionScreen> {
     print('Received message from unity: ${message.toString()}');
   }
 
-  void onUnitySceneLoaded(SceneLoaded scene) {
-    print('Received scene loaded from unity: ${scene.name}');
-    print('Received scene loaded from unity buildIndex: ${scene.buildIndex}');
+  void onUnitySceneLoaded(SceneLoaded? scene) {
+    if (scene != null) {
+      print('Received scene loaded from unity: ${scene.name}');
+      print('Received scene loaded from unity buildIndex: ${scene.buildIndex}');
+    } else {
+      print('Received scene loaded from unity: null');
+    }
   }
 
   // Callback that connects the created controller to the unity controller

--- a/example/lib/screens/orientation_screen.dart
+++ b/example/lib/screens/orientation_screen.dart
@@ -4,14 +4,14 @@ import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 class OrientationScreen extends StatefulWidget {
-  OrientationScreen({Key key}) : super(key: key);
+  OrientationScreen({Key? key}) : super(key: key);
 
   @override
   _LoaderScreenState createState() => _LoaderScreenState();
 }
 
 class _LoaderScreenState extends State<OrientationScreen> {
-  UnityWidgetController _unityWidgetController;
+  UnityWidgetController? _unityWidgetController;
   double _sliderValue = 0.0;
 
   @override
@@ -90,7 +90,7 @@ class _LoaderScreenState extends State<OrientationScreen> {
   }
 
   void setRotationSpeed(String speed) {
-    _unityWidgetController.postMessage(
+    _unityWidgetController?.postMessage(
       'Cube',
       'SetRotationSpeed',
       speed,

--- a/example/lib/screens/orientation_screen.dart
+++ b/example/lib/screens/orientation_screen.dart
@@ -4,13 +4,13 @@ import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 class OrientationScreen extends StatefulWidget {
-  OrientationScreen({Key? key}) : super(key: key);
+  const OrientationScreen({Key? key}) : super(key: key);
 
   @override
-  _LoaderScreenState createState() => _LoaderScreenState();
+  State<OrientationScreen> createState() => _OrientationScreenState();
 }
 
-class _LoaderScreenState extends State<OrientationScreen> {
+class _OrientationScreenState extends State<OrientationScreen> {
   UnityWidgetController? _unityWidgetController;
   double _sliderValue = 0.0;
 
@@ -23,7 +23,7 @@ class _LoaderScreenState extends State<OrientationScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Orientation Screen'),
+        title: const Text('Orientation Screen'),
       ),
       body: Card(
         margin: const EdgeInsets.all(8),
@@ -61,10 +61,10 @@ class _LoaderScreenState extends State<OrientationScreen> {
                                 [DeviceOrientation.portraitUp]);
                           }
                         },
-                        child: Text("Change Orientation"),
+                        child: const Text("Change Orientation"),
                       ),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 20),
+                      const Padding(
+                        padding: EdgeInsets.only(top: 20),
                         child: Text("Rotation speed:"),
                       ),
                       Slider(
@@ -103,6 +103,6 @@ class _LoaderScreenState extends State<OrientationScreen> {
 
   // Callback that connects the created controller to the unity controller
   void onUnityCreated(controller) {
-    this._unityWidgetController = controller;
+    _unityWidgetController = controller;
   }
 }

--- a/example/lib/screens/simple_screen.dart
+++ b/example/lib/screens/simple_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 class SimpleScreen extends StatefulWidget {
-  SimpleScreen({Key key}) : super(key: key);
+  SimpleScreen({Key? key}) : super(key: key);
 
   @override
   _SimpleScreenState createState() => _SimpleScreenState();
@@ -13,7 +13,7 @@ class _SimpleScreenState extends State<SimpleScreen> {
   static final GlobalKey<ScaffoldState> _scaffoldKey =
       GlobalKey<ScaffoldState>();
 
-  UnityWidgetController _unityWidgetController;
+  UnityWidgetController? _unityWidgetController;
   double _sliderValue = 0.0;
 
   @override
@@ -23,7 +23,7 @@ class _SimpleScreenState extends State<SimpleScreen> {
 
   @override
   void dispose() {
-    _unityWidgetController.dispose();
+    _unityWidgetController?.dispose();
     super.dispose();
   }
 
@@ -84,7 +84,7 @@ class _SimpleScreenState extends State<SimpleScreen> {
   }
 
   void setRotationSpeed(String speed) {
-    _unityWidgetController.postMessage(
+    _unityWidgetController?.postMessage(
       'Cube',
       'SetRotationSpeed',
       speed,
@@ -95,9 +95,13 @@ class _SimpleScreenState extends State<SimpleScreen> {
     print('Received message from unity: ${message.toString()}');
   }
 
-  void onUnitySceneLoaded(SceneLoaded scene) {
-    print('Received scene loaded from unity: ${scene.name}');
-    print('Received scene loaded from unity buildIndex: ${scene.buildIndex}');
+  void onUnitySceneLoaded(SceneLoaded? scene) {
+    if (scene != null) {
+      print('Received scene loaded from unity: ${scene.name}');
+      print('Received scene loaded from unity buildIndex: ${scene.buildIndex}');
+    } else {
+      print('Received scene loaded from unity: null');
+    }
   }
 
   // Callback that connects the created controller to the unity controller

--- a/example/lib/screens/simple_screen.dart
+++ b/example/lib/screens/simple_screen.dart
@@ -3,10 +3,10 @@ import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 class SimpleScreen extends StatefulWidget {
-  SimpleScreen({Key? key}) : super(key: key);
+  const SimpleScreen({Key? key}) : super(key: key);
 
   @override
-  _SimpleScreenState createState() => _SimpleScreenState();
+  State<SimpleScreen> createState() => _SimpleScreenState();
 }
 
 class _SimpleScreenState extends State<SimpleScreen> {
@@ -32,7 +32,7 @@ class _SimpleScreenState extends State<SimpleScreen> {
     return Scaffold(
       key: _scaffoldKey,
       appBar: AppBar(
-        title: Text('Simple Screen'),
+        title: const Text('Simple Screen'),
       ),
       body: Card(
           margin: const EdgeInsets.all(0),
@@ -47,7 +47,7 @@ class _SimpleScreenState extends State<SimpleScreen> {
                 onUnityMessage: onUnityMessage,
                 onUnitySceneLoaded: onUnitySceneLoaded,
                 useAndroidViewSurface: false,
-                borderRadius: BorderRadius.all(Radius.circular(70)),
+                borderRadius: const BorderRadius.all(Radius.circular(70)),
               ),
               PointerInterceptor(
                 child: Positioned(
@@ -58,8 +58,8 @@ class _SimpleScreenState extends State<SimpleScreen> {
                     elevation: 10,
                     child: Column(
                       children: <Widget>[
-                        Padding(
-                          padding: const EdgeInsets.only(top: 20),
+                        const Padding(
+                          padding: EdgeInsets.only(top: 20),
                           child: Text("Rotation speed:"),
                         ),
                         Slider(
@@ -107,6 +107,6 @@ class _SimpleScreenState extends State<SimpleScreen> {
   // Callback that connects the created controller to the unity controller
   void _onUnityCreated(controller) {
     controller.resume();
-    this._unityWidgetController = controller;
+    _unityWidgetController = controller;
   }
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the flutter_unity_widget plugin.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.0

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_unity_widget_example/main.dart';
 void main() {
   testWidgets('Verify Platform version', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(const MyApp());
 
     // Verify that platform version is retrieved.
     expect(

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -19,7 +19,7 @@ void main() {
     expect(
       find.byWidgetPredicate(
         (Widget widget) =>
-            widget is Text && widget.data.startsWith('Running on:'),
+            widget is Text && (widget.data?.startsWith('Running on:') ?? false),
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
## Note
This is the same change as #732, but based on the global_unity_controller feature branch #733 as requested.
In that branch only `api_screen.dart` was already updated for the new API changes, so the other pages might still be outdated.

## Description

<!--- Describe your changes in detail -->
The example code can't simply be pasted into a modern flutter project. It will show errors, mainly due to null-safety changes.
Given that the plugin supports null-safety from version 4.2.0 (18 months ago), it's safe to update the example.

The last commit is a small cleanup by following most suggestions of flutter_lints.



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
