### PR TITLE
fix(Unity Demo): fix setRotatioSpeed float Parsing

### DIFF
--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Demo/Rotate.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Demo/Rotate.cs
@@ -2,6 +2,7 @@
 using FlutterUnityIntegration;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using System.Globalization;
 
 public class Rotate : MonoBehaviour, IEventSystemHandler
 {
@@ -39,7 +40,7 @@ public class Rotate : MonoBehaviour, IEventSystemHandler
     // This method is called from Flutter
     public void SetRotationSpeed(String message)
     {
-        float value = float.Parse(message);
+        float value = float.Parse(message , CultureInfo.InvariantCulture.NumberFormat);
         RotateAmount = new Vector3(value, value, value);
     }
 }


### PR DESCRIPTION
## Description

When launching the demo on flutter Android you couldn't change the rotation speed
because it was Parsed in such a way that the "0.0" format throwed a
Parsing Error

Now it doesn't :robot:

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
