### PR TITLE
Fix broken UnityReady trigger in iOS exports.

### DIFF
--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -211,7 +211,7 @@ namespace FlutterUnityIntegration.Editor
             #if UNITY_2022_1_OR_NEWER
                 PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.Android, isReleaseBuild ? Il2CppCompilerConfiguration.Release : Il2CppCompilerConfiguration.Debug);
                 PlayerSettings.SetIl2CppCodeGeneration(UnityEditor.Build.NamedBuildTarget.Android, UnityEditor.Build.Il2CppCodeGeneration.OptimizeSize);
-            #elif UNITY_2020_3_OR_NEWER
+            #elif UNITY_2021_2_OR_NEWER
                 PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.Android, isReleaseBuild ? Il2CppCompilerConfiguration.Release : Il2CppCompilerConfiguration.Debug);
                 EditorUserBuildSettings.il2CppCodeGeneration = UnityEditor.Build.Il2CppCodeGeneration.OptimizeSize;
             #endif
@@ -372,7 +372,7 @@ body { padding: 0; margin: 0; overflow: hidden; }
             #if UNITY_2022_1_OR_NEWER
                 PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.iOS, isReleaseBuild ? Il2CppCompilerConfiguration.Release : Il2CppCompilerConfiguration.Debug);
                 PlayerSettings.SetIl2CppCodeGeneration(UnityEditor.Build.NamedBuildTarget.iOS, UnityEditor.Build.Il2CppCodeGeneration.OptimizeSize);
-            #elif UNITY_2020_3_OR_NEWER
+            #elif UNITY_2021_2_OR_NEWER
                 PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.iOS, isReleaseBuild ? Il2CppCompilerConfiguration.Release : Il2CppCompilerConfiguration.Debug);
                 EditorUserBuildSettings.il2CppCodeGeneration = UnityEditor.Build.Il2CppCodeGeneration.OptimizeSize;
             #endif

--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/XCodePostBuild.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/XCodePostBuild.cs
@@ -24,6 +24,7 @@ using System;
 
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 using UnityEditor;
 using UnityEditor.Callbacks;
@@ -325,7 +326,9 @@ public static class XcodePostBuild
             inScope |= line.Contains("- (void)startUnity:");
             markerDetected |= inScope && line.Contains(TouchedMarker);
 
-            if (inScope && line.Trim() == "}")
+            //Find the end of the startUnity function, a } without any indentation.  (regex: starts with } followed by any whitespace)
+            //Avoid indentation before } as newer unity versions include an if-statement inside this function.
+            if (inScope && Regex.Match(line, @"^}(\s)*$").Success)
             {
                 inScope = false;
 
@@ -335,6 +338,7 @@ public static class XcodePostBuild
                 }
                 else
                 {
+                    //Add a UnityReady notification at the end of the startUnity function.
                     return new string[]
                     {
                         "    // Modified by " + TouchedMarker,


### PR DESCRIPTION
## Description

This is based on #554 and is the cause for some white screen issues on iOS.
#595 seems to be a workaround for the bug caused by this.

The `XcodePostBuild.cs` script adds a notification trigger into `\ios\UnityLibrary\Classes\UnityAppController.mm`, which is used by the plugin.
The script searches for `}` to find the end of the `startUnity` function and places additional lines there, which works for older Unity versions like 2019.4.23 or 2020.3.6.
This fails with newer Unity versions because of an if-statement that provides an earlier `}`.

## 
The old and correct way:
```diff
{ // 2020.3.6f1
    ...

    AVAudioSession* audioSession = [AVAudioSession sharedInstance];
    [audioSession setActive: YES error: nil];
    [audioSession addObserver: self forKeyPath: @"outputVolume" options: 0 context: nil];
    UnityUpdateMuteState([audioSession outputVolume] < 0.01f ? 1 : 0);

#if UNITY_REPLAY_KIT_AVAILABLE
    void InitUnityReplayKit();  // Classes/Unity/UnityReplayKit.mm

    InitUnityReplayKit();
#endif
-}
+    // Modified by https://github.com/juicycleff/flutter-unity-view-widget
+   [[NSNotificationCenter defaultCenter] postNotificationName: @"UnityReady" object:self];
+}
```
## 
Newer broken outputs:
```diff
{ //2020.3.31f1
    ...

    AVAudioSession* audioSession = [AVAudioSession sharedInstance];
    [audioSession setCategory: AVAudioSessionCategoryAmbient error: nil];
    if (UnityIsAudioManagerAvailableAndEnabled())
    {
        if (UnityShouldPrepareForIOSRecording())
        {
            [audioSession setCategory: AVAudioSessionCategoryPlayAndRecord error: nil];
-       }
+    // Modified by https://github.com/juicycleff/flutter-unity-view-widget
+   [[NSNotificationCenter defaultCenter] postNotificationName: @"UnityReady" object:self];
+}
        else if (UnityShouldMuteOtherAudioSources())
        {
            [audioSession setCategory: AVAudioSessionCategorySoloAmbient error: nil];
        }
    }

    [audioSession setActive: YES error: nil];
    [audioSession addObserver: self forKeyPath: @"outputVolume" options: 0 context: nil];
    UnityUpdateMuteState([audioSession outputVolume] < 0.01f ? 1 : 0);

#if UNITY_REPLAY_KIT_AVAILABLE
    void InitUnityReplayKit();  // Classes/Unity/UnityReplayKit.mm

    InitUnityReplayKit();
#endif
}
```

## Fix
This is an adaptation of the fix suggested in #554.
It removes `line.Trim()` in the string replacement so that it can skip a `}` that has indentation.
The regex is used as a precaution to make the match more flexible with possible spaces/tabs/line breaks at the end of the line.

While testing Untiy 2020.3.x I also fixed a small compilation error in `Build.cs`.

## Testing
If you want to test this change, don't forget to delete the unityLibrary folder before trying a new export.
The export script will skip this file if it has been edited already.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
