### PR TITLE
Disable bitcode for Xcode 14.

### DIFF
--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/XCodePostBuild.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/XCodePostBuild.cs
@@ -77,7 +77,7 @@ public static class XcodePostBuild
         pbx.SetBuildProperty(targetGuid, "SKIP_INSTALL", "YES");
 
         // Set some linker flags
-        pbx.SetBuildProperty(projGuid, "ENABLE_BITCODE", "YES");
+        pbx.SetBuildProperty(projGuid, "ENABLE_BITCODE", "NO");
 
         // Persist changes
         pbx.WriteToFile(pbxPath);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Xcode 14 deprecates bitcode, and since today Flutter 3.7 has dropped support for bitcode.
We should disable this setting in the iOS export.

Anyone that still needs it for older projects can simply turn it on again or use an older unitypackage.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [X] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
