### PR TITLE
[Unitypackage] Improve WebGL export 

### DIFF
--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -179,7 +179,6 @@ namespace FlutterUnityIntegration.Editor
             if (report.summary.result != BuildResult.Succeeded)
                 throw new Exception("Build failed");
 
-            // Copy(path, WebExportPath);
             ModifyWebGLExport();
 
             Debug.Log("-- WebGL Build: SUCCESSFUL --");
@@ -252,26 +251,27 @@ namespace FlutterUnityIntegration.Editor
             var indexFile = Path.Combine(WebExportPath, "index.html");
             var indexHtmlText = File.ReadAllText(indexFile);
 
+            //define extra functions and listeners in Unity's index.html
             indexHtmlText = indexHtmlText.Replace("<script>", @"
     <script>
         var mainUnityInstance;
 
         window['handleUnityMessage'] = function (params) {
-        window.parent.postMessage({
-            name: 'onUnityMessage',
-            data: params,
+            window.parent.postMessage({
+                name: 'onUnityMessage',
+                data: params,
             }, '*');
         };
 
         window['handleUnitySceneLoaded'] = function (name, buildIndex, isLoaded, isValid) {
-        window.parent.postMessage({
-            name: 'onUnitySceneLoaded',
-            data: {
-                'name': name,
-                'buildIndex': buildIndex,
-                'isLoaded': isLoaded == 1,
-                'isValid': isValid == 1,
-            }
+            window.parent.postMessage({
+                name: 'onUnitySceneLoaded',
+                data: {
+                    'name': name,
+                    'buildIndex': buildIndex,
+                    'isLoaded': isLoaded == 1,
+                    'isValid': isValid == 1,
+                }
             }, '*');
         };
 

--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -285,9 +285,13 @@ namespace FlutterUnityIntegration.Editor
         });
         ");
 
-            indexHtmlText = indexHtmlText.Replace("canvas.style.width = \"960px\";", "canvas.style.width = \"100%\";");
-			indexHtmlText = indexHtmlText.Replace("canvas.style.height = \"600px\";", "canvas.style.height = \"100%\";");
+            //Adjust the size of the Unity canvas
+            int height = PlayerSettings.defaultWebScreenHeight;
+            int width = PlayerSettings.defaultWebScreenWidth;
+            indexHtmlText = indexHtmlText.Replace($"canvas.style.width = \"{width}px\";", "canvas.style.width = \"100%\";");
+            indexHtmlText = indexHtmlText.Replace($"canvas.style.height = \"{height}px\";", "canvas.style.height = \"100%\";");
 
+            // Handle unity Initialization
 			indexHtmlText = indexHtmlText.Replace("}).then((unityInstance) => {", @"
          }).then((unityInstance) => {
            window.parent.postMessage('unityReady', '*');

--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -154,8 +154,8 @@ namespace FlutterUnityIntegration.Editor
 
         private static void BuildWebGL(String path)
         {
-            // Switch to Android standalone build.
-            EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.Android, BuildTarget.Android);
+            // Switch to WebGL standalone build.
+            EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.WebGL, BuildTarget.WebGL);
 
             if (Directory.Exists(path))
                 Directory.Delete(path, true);
@@ -170,7 +170,7 @@ namespace FlutterUnityIntegration.Editor
             playerOptions.target = BuildTarget.WebGL;
             playerOptions.locationPathName = path;
 
-            // Switch to Android standalone build.
+            // Switch to WebGL standalone build.
             EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.WebGL, BuildTarget.WebGL);
             // build addressable
             ExportAddressables();

--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -309,10 +309,17 @@ namespace FlutterUnityIntegration.Editor
             string widthString = $"canvas.style.width = \"{width}px\";";
             string heightString = $"canvas.style.height = \"{height}px\";";
 
+            string u2019SizeString = $"style=\"width: {width}px; height: {height}px";
+
             if (indexHtmlText.Contains(widthString) || indexHtmlText.Contains(heightString)) {
                 indexHtmlText = indexHtmlText.Replace(widthString, "canvas.style.width = \"100%\";");
                 indexHtmlText = indexHtmlText.Replace(heightString, "canvas.style.height = \"100%\";");
-            } else
+            } 
+            //check for unity 2019 style html
+            else if (indexHtmlText.Contains(u2019SizeString))
+            {
+                indexHtmlText = indexHtmlText.Replace(u2019SizeString, "style=\"width: 100%; height: 100%");
+            } else 
             {
                 //Let the user know the export didn't go fully as expected
                 Debug.LogError("Failed to set the size of the canvas in Unity's index.html.");
@@ -322,6 +329,7 @@ namespace FlutterUnityIntegration.Editor
             // Handle unity Initialization
 
             string unityInstanceString = "}).then((unityInstance) => {";
+            string u2019InstanceString = "var unityInstance = UnityLoader.instantiate";
             if (indexHtmlText.Contains(unityInstanceString)) {
 
                 indexHtmlText = indexHtmlText.Replace(unityInstanceString, @"
@@ -329,6 +337,13 @@ namespace FlutterUnityIntegration.Editor
            window.parent.postMessage('unityReady', '*');
            mainUnityInstance = unityInstance;
                 ");
+            }
+            //check for unity 2019 style html
+            else if (indexHtmlText.Contains(u2019InstanceString)) {
+                indexHtmlText = indexHtmlText.Replace("  </script>", @"
+         window.parent.postMessage('unityReady', '*');
+         mainUnityInstance = unityInstance;
+    </script>");
             } else
             {
                 //Let the user know the export didn't go fully as expected
@@ -339,12 +354,13 @@ namespace FlutterUnityIntegration.Editor
 
 			File.WriteAllText(indexFile, indexHtmlText);
 
-			/// Modidy style.css
+			/// Modidy style.css (mostly applies to Unity 2020+ as 2019 uses different classes and ids)
 			var cssFile = Path.Combine($"{WebExportPath}/TemplateData", "style.css");
 			var fullScreenCss = File.ReadAllText(cssFile);
 			fullScreenCss = @"
 body { padding: 0; margin: 0; overflow: hidden; }
 #unity-container { position: absolute }
+#unityContainer { position: absolute } /*unity 2019*/
 #unity-container.unity-desktop { width: 100%; height: 100% }
 #unity-container.unity-mobile { width: 100%; height: 100% }
 #unity-canvas { background: #231F20 }
@@ -355,6 +371,7 @@ body { padding: 0; margin: 0; overflow: hidden; }
 #unity-progress-bar-full { width: 0%; height: 18px; margin-top: 10px; background: url('progress-bar-full-dark.png') no-repeat center }
 #unity-footer { display: none }
 .unity-mobile #unity-footer { display: none }
+.footer { display:none } /*unity 2019*/
 #unity-webgl-logo { float:left; width: 204px; height: 38px; background: url('webgl-logo.png') no-repeat center }
 #unity-build-title { float: right; margin-right: 10px; line-height: 38px; font-family: arial; font-size: 18px }
 #unity-fullscreen-button { float: right; width: 38px; height: 38px; background: url('fullscreen-button.png') no-repeat center }

--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -291,7 +291,7 @@ namespace FlutterUnityIntegration.Editor
         });
 
         window.parent.addEventListener('unityFlutterBidingFnCal', function (args) {
-            mainUnityInstance.SendMessage('GameManager', 'HandleWebFnCall', args);
+            mainUnityInstance.SendMessage('GameManager', 'HandleWebFnCall', args.data);
         });
                 ");
             } else


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

For WebGL exports, the function `ModifyWebGLExport` adds some extra functionality to Unity's index.html using `string.replace`.
Even If this replacing fails, the build will succeed and the user gets bugs or unintended behaviour in the browser.

For example WebGL doesn't work properly when exported using Unity 2019.

##

This pull request:
- Makes the search and replace more robust to player setting changes
- Improves compatibility with the Unity 2019 index.html
- Log errors for the user when the replace did not succeed
- Fixes an unrelated bug that broke the `pause` and `resume` functions.

This probably won't fix every single Unity version, but users will now get an error message that might help in finding the problem.

##

Tested this to work with Unity:
2022.2.5, 2021.3.14, 2020.3.42, 2019.4.40, 2019.4.23

Based on #754 I assume that 2022.1.0b5 doesn't work yet, but that is an (outdated) beta release.
This also fixes #755.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
