### PR TITLE
Replace the webviewx package with webview_flutter_web.

### DIFF
--- a/lib/src/web/web_unity_widget_view.dart
+++ b/lib/src/web/web_unity_widget_view.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:webviewx/webviewx.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 
 class WebUnityWidgetView extends StatefulWidget {
   const WebUnityWidgetView({
@@ -16,6 +16,11 @@ class WebUnityWidgetView extends StatefulWidget {
 }
 
 class _WebUnityWidgetViewState extends State<WebUnityWidgetView> {
+  final WebViewController _controller = WebViewController()
+    ..loadRequest(
+      Uri.parse('${Uri.base.origin}/UnityLibrary/index.html'),
+    );
+
   @override
   void initState() {
     super.initState();
@@ -29,13 +34,6 @@ class _WebUnityWidgetViewState extends State<WebUnityWidgetView> {
 
   @override
   Widget build(BuildContext context) {
-    return WebViewX(
-      initialContent: '${Uri.base.origin}/UnityLibrary/index.html',
-      initialSourceType: SourceType.url,
-      javascriptMode: JavascriptMode.unrestricted,
-      onWebViewCreated: (_) {},
-      height: MediaQuery.of(context).size.height,
-      width: MediaQuery.of(context).size.width,
-    );
+    return WebViewWidget(controller: _controller);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,8 @@ dependencies:
   flutter_plugin_android_lifecycle: ^2.0.7
   stream_transform: ^2.0.0
   plugin_platform_interface: ^2.1.2
-  webviewx: ^0.2.1
+  webview_flutter: ^4.0.0
+  webview_flutter_web: ^0.2.2
 #  ffi: ^1.2.1 // required for windows support
 
 dev_dependencies:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This replaces the [webviewx](https://pub.dev/packages/webviewx) package with [webview_flutter_web](https://pub.dev/packages/webview_flutter_web). These are only used on the web platform.

The webviewx package relies on `webview_flutter: ^2.0.13`, which is currently at `4.0.2`. This causes issues when a different webview is used in an app using a UnityWidget. #738

A workaround was to use dependency overrides in pubspec.yaml.
```
dependency_overrides:
  webview_flutter: [VERSION_YOU_NEED]
```

A recent webview_flutter_web update (0.2.2) makes it compatible with the Unity export. 
To make things future-proof, let's change this to a webview that isn't abandoned.

## Testing
The example project seems to work as expected.
I'd love feedback from anyone using Unity in a web project to see how this performs.

@Ahmadre Given that you added web, maybe you can take a look. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
