### PR TITLE
[ios] Replace the Unity PostBuild callback to avoid UnityAppController errors.

### DIFF
--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -397,6 +397,11 @@ body { padding: 0; margin: 0; overflow: hidden; }
             if (report.summary.result != BuildResult.Succeeded)
                 throw new Exception("Build failed");
 
+            //trigger postbuild script manually
+#if UNITY_IOS
+            XcodePostBuild.PostBuild(BuildTarget.iOS, report.summary.outputPath);
+#endif
+
             if (isReleaseBuild) {
                 Debug.Log("-- iOS Release Build: SUCCESSFUL --");
             } else {

--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/XCodePostBuild.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/XCodePostBuild.cs
@@ -26,9 +26,7 @@ using System.Collections.Generic;
 using System.IO;
 
 using UnityEditor;
-using UnityEditor.Callbacks;
 using UnityEditor.iOS.Xcode;
-using UnityEngine;
 
 /// <summary>
 /// Adding this post build script to Unity project enables the flutter-unity-widget to access it
@@ -42,8 +40,8 @@ public static class XcodePostBuild
     /// </summary>
     private const string TouchedMarker = "https://github.com/juicycleff/flutter-unity-view-widget";
 
-    [PostProcessBuild]
-    public static void OnPostBuild(BuildTarget target, string pathToBuiltProject)
+    //trigger this manually from build.cs as [PostProcessBuild] or IPostprocessBuildWithReport don't always seem to trigger.
+    public static void PostBuild(BuildTarget target, string pathToBuiltProject)
     {
         if (target != BuildTarget.iOS)
         {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
For some users the iOS export is broken because `UnityAppController.h` and `UnityAppController.m` are never edited.
This usually results in errors like 
`Value of type 'UnityAppController' has no member 'unityMessageHandler` and 
`Value of type 'UnityAppController' has no member 'unitySceneLoadedHandler`.

This should be done by the `XcodePostBuild.cs` script which is triggered by the Unity callback `[PostProcessBuild]`.
It seems like this callback isn't called in some cases.

Sometimes exporting again or cleaning the project might help, but that doesn't fix that this code somehow gets skipped.


This has popped up on Discord and in multiple issues like #426 #377 #486 #756 and more.

## Change
Call the post-build function directly when a build succeeds, instead of relying on the callback from Unity.
This should make the execution of the function guaranteed.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
