### PR TITLE
Add Android Gradle Plugin (AGP) 8.0 compatibility.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,10 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 29
 
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.xraph.plugin.flutter_unity_widget'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -27,6 +27,10 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 31
+    
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.xraph.plugin.flutter_unity_widget_example'
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -331,6 +331,14 @@ body { padding: 0; margin: 0; overflow: hidden; }
             buildText = buildText.Replace("implementation fileTree(dir: 'libs', include: ['*.jar'])", "implementation(name: 'unity-classes', ext:'jar')");
             buildText = buildText.Replace(" + unityStreamingAssets.tokenize(', ')", "");
 
+            // check for namespace definition (Android gradle plugin 8+), add a backwards compatible version if it is missing.
+            if(!buildText.Contains("namespace")) 
+            {
+                buildText = buildText.Replace("compileOptions {",
+                    "if (project.android.hasProperty(\"namespace\")) {\n        namespace 'com.unity3d.player'\n    }\n\n    compileOptions {"
+                );
+            }
+
             if(isPlugin)
             {
                 buildText = Regex.Replace(buildText, @"implementation\(name: 'androidx.* ext:'aar'\)", "\n");


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description


Android Gradle Plugin 8.0 requires a namespace definition in some build.gradle files.
This is incompatible with the current plugin 2022.2.0.

After updating to AGP 8.0, you will get errors like this:
```
* Where:
Build file '...\flutter_unity_widget\example\android\build.gradle' line: 31

* What went wrong:
A problem occurred evaluating root project 'android'.
> A problem occurred configuring project ':app'.
   > Could not create an instance of type com.android.build.api.variant.impl.ApplicationVariantImpl.
      > Namespace not specified. Please specify a namespace in the module's build.gradle file like so:

        android {
            namespace 'com.example.namespace'
        }

        If the package attribute is specified in the source AndroidManifest.xml, it can be migrated automatically to the namespace value in the build.gradle file using the AGP Upgrade Assistant; please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
```


This pull request adds backwards compatible namespace definitions, following the example of the official Flutter plugins.

- Adds the namespace to the plugin build.gradle and example/app/build.gradle
- Makes the Unity export script add the namespace to unityLibrary/build.gradle.

### Testing:
(1,2 and 3 can be done by manually editing gradle files too)

1. Install Android Studio Flamingo (2022.2.x) or newer.
2. Open Example/android in Android studio.
3.  Use the upgrade assistant to update Gradle to 8.0 and the Gradle plugin (AGP) to 8.0.
  (it should pop up automatically, otherwise open it from `Tools -> AGP upgrade assistant`)
4. Export Android from Unity
5.  Build/Run the flutter app.

The build should work again with these changes.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
