### PR TITLE
[Web] Fix PointerInterceptor in examples blocking all clicks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ These instructions assume you are using a new Unity project. If you open the exa
   - (iOS) Select **Target SDK** depending on where you will run your app (simulator or physical device).  
     We recommend starting with a physical device and the `Device SDK` setting, due to limited simulator support.
 
+  - (Web) Set <b>Publishing settings > Compression format</b> to Brotli or Disabled.  
+  Some users report that Unity gets stuck on the loading screen with the Gzip setting, due to MIME type errors.
+
   <img src="https://raw.githubusercontent.com/juicycleff/flutter-unity-view-widget/master/files/Screenshot%202019-03-27%2007.31.55.png" width="400" />
 
 5. In **File > Build Settings**, make sure to have at least 1 scene added to your build.

--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ class _MyAppState extends State<MyApp> {
                 bottom: 20,
                 left: 20,
                 right: 20,
+                // <You need a PointerInterceptor here on web>
                 child: Card(
                   elevation: 10,
                   child: Column(
@@ -885,17 +886,35 @@ Flutter on default doesn't support `--flavor` for building web. But you can set 
 
 ### Web GL
 
-> If you develop and ship Flutter with Unity WebGL then you will first notice, that stacked Widgets over your UnityWidget are not tappable!
-
-This is actually a Flutter related Issue (See: https://github.com/flutter/flutter/issues/72273).
-
-To solve this, Flutter-Team already got a solution for this. Use: [PointerInterceptor](https://pub.dev/packages/pointer_interceptor)!
+Flutter widgets stacked on top of the UnityWidget will not register clicks or taps. This is a [Flutter issue](https://github.com/flutter/flutter/issues/72273) and can be solved by using the  [PointerInterceptor](https://pub.dev/packages/pointer_interceptor) package.
 
 Example usage:
 
-![PointerInterceptor](https://github.com/juicycleff/flutter-unity-view-widget/blob/master/files/PointerInterceptor.png?raw=true)
+```dart
+Stack(
+  children: [
+    UnityWidget(
+      onUnityCreated: onUnityCreated,
+      onUnityMessage: onUnityMessage,
+      onUnitySceneLoaded: onUnitySceneLoaded,
+    ),
+    Positioned(
+      bottom: 20,
+      left: 20,
+      right: 20,
+      child: PointerInterceptor(
+        child: ElevatedButton(
+          onPressed: () {
+            // do something
+          },
+          child: const Text('Example button'),
+        ),
+      ),
+    ),
+```
 
-Note: We already integrated this into our [Examples](/example/lib/screens/) in the `/example` folder.
+
+We already integrated this into our [Examples](/example/lib/screens/) in the `/example` folder.
 
 
 #### Sponsors

--- a/example/lib/screens/api_screen.dart
+++ b/example/lib/screens/api_screen.dart
@@ -47,11 +47,11 @@ class _ApiScreenState extends State<ApiScreen> {
               fullscreen: false,
               useAndroidViewSurface: false,
             ),
-            PointerInterceptor(
-              child: Positioned(
-                bottom: 20,
-                left: 20,
-                right: 20,
+            Positioned(
+              bottom: 20,
+              left: 20,
+              right: 20,
+              child: PointerInterceptor(
                 child: Card(
                   elevation: 10,
                   child: Column(

--- a/example/lib/screens/loader_screen.dart
+++ b/example/lib/screens/loader_screen.dart
@@ -39,11 +39,11 @@ class _LoaderScreenState extends State<LoaderScreen> {
               onUnityMessage: onUnityMessage,
               useAndroidViewSurface: true,
             ),
-            PointerInterceptor(
-              child: Positioned(
-                bottom: 20,
-                left: 20,
-                right: 20,
+            Positioned(
+              bottom: 20,
+              left: 20,
+              right: 20,
+              child: PointerInterceptor(
                 child: Card(
                   elevation: 10,
                   child: Column(

--- a/example/lib/screens/no_interaction_screen.dart
+++ b/example/lib/screens/no_interaction_screen.dart
@@ -48,11 +48,11 @@ class _NoInteractionScreenState extends State<NoInteractionScreen> {
               useAndroidViewSurface: true,
               borderRadius: const BorderRadius.all(Radius.circular(70)),
             ),
-            PointerInterceptor(
-              child: Positioned(
-                bottom: 20,
-                left: 20,
-                right: 20,
+            Positioned(
+              bottom: 20,
+              left: 20,
+              right: 20,
+              child: PointerInterceptor(
                 child: ElevatedButton(
                   onPressed: () {
                     Navigator.of(context).pushNamed('/simple');

--- a/example/lib/screens/orientation_screen.dart
+++ b/example/lib/screens/orientation_screen.dart
@@ -38,11 +38,11 @@ class _OrientationScreenState extends State<OrientationScreen> {
               onUnityMessage: onUnityMessage,
               useAndroidViewSurface: true,
             ),
-            PointerInterceptor(
-              child: Positioned(
-                bottom: 20,
-                left: 20,
-                right: 20,
+            Positioned(
+              bottom: 20,
+              left: 20,
+              right: 20,
+              child: PointerInterceptor(
                 child: Card(
                   elevation: 10,
                   child: Column(

--- a/example/lib/screens/simple_screen.dart
+++ b/example/lib/screens/simple_screen.dart
@@ -49,11 +49,11 @@ class _SimpleScreenState extends State<SimpleScreen> {
                 useAndroidViewSurface: false,
                 borderRadius: const BorderRadius.all(Radius.circular(70)),
               ),
-              PointerInterceptor(
-                child: Positioned(
-                  bottom: 0,
-                  left: 0,
-                  right: 0,
+              Positioned(
+                bottom: 0,
+                left: 0,
+                right: 0,
+                child: PointerInterceptor(
                   child: Card(
                     elevation: 10,
                     child: Column(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Web needs a PointerInterceptor to be able to click on any widget on top of the UnityWidget.
However in the way this is used in the examples, all clicks are intercepted and none will ever reach Unity #827.


This is because it is wrapped around a `Positioned`, and will take the full dimensions of the Stack.

This pull request simply moves the PointerInterceptor down in the hierarchy, so that it shrinks in size to fit the widget that needs mouse input

- I also added a note about web compression to the readme, as this issue has popped up in Discord multiple times.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
