### PR TITLE
Fix incomplete iOS export after build target switch.

### DIFF
--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -356,15 +356,17 @@ body { padding: 0; margin: 0; overflow: hidden; }
 
         private static void BuildIOS(String path, bool isReleaseBuild)
         {
+            bool abortBuild = false;
+
             // abort iOS export if #UNITY_IOS is false.
             // Even after SwitchActiveBuildTarget() it will still be false as the code isn't recompiled yet.
             // As a workaround, make the user trigger an export again after the switch.
 
 #if !UNITY_IOS
+            abortBuild = true;
             if (Application.isBatchMode)
             {
                 Debug.LogError("Incorrect iOS buildtarget, use the -buildTarget argument to set iOS");
-                return;
             }
             else
             {
@@ -378,10 +380,11 @@ body { padding: 0; margin: 0; overflow: hidden; }
                 {
                     EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.iOS, BuildTarget.iOS);
                 }
-
-                return;
             } 
 #endif
+            //don't return within #if !UNITY_IOS as that results in unreachable code warnings.
+            if (abortBuild)
+                return;
 
             if (Directory.Exists(path))
                 Directory.Delete(path, true);


### PR DESCRIPTION
## Description
Clicking 'Export iOS' while on a different build target (like android) will result in an incomplete export.  
The same might happen from the command line if `-buildTarget iOS` is omitted from the arguments.  

This results in errors like 
`Value of type 'UnityAppController' has no member 'unityMessageHandler` and 
`Value of type 'UnityAppController' has no member 'unitySceneLoadedHandler`.

This issue is a sequel to #782, and might be a cause for issues like #426 #377 #486 #756 and more.


## Problem
The build script will switch to iOS using `SwitchActiveBuildTarget()` and then continue the export.  
However `#if UNITY_IOS` still returns false during this export, which ensures some code in XcodePostBuild will never be executed.  

Unity needs a full recompile to change `#if UNITY_` values, which can't happen within the same function.

## Solution
I tried multiple approaches that wait for and detect a recompile, but none were reliable in all supported Unity versions.

In the end I decided to show a dialog requesting the user to run 'Export iOS' again, after the buildtarget has switched and scripts have been recompiled.


<img src="https://github.com/juicycleff/flutter-unity-view-widget/assets/11444698/2395257b-2260-48d7-8978-722724fe7905" width="50%"/>


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
