### PR TITLE
Add support for web base not being on the root

### DIFF
--- a/lib/src/web/web_unity_widget_view.dart
+++ b/lib/src/web/web_unity_widget_view.dart
@@ -18,7 +18,7 @@ class WebUnityWidgetView extends StatefulWidget {
 class _WebUnityWidgetViewState extends State<WebUnityWidgetView> {
   final WebViewController _controller = WebViewController()
     ..loadRequest(
-      Uri.parse('${Uri.base.origin}/UnityLibrary/index.html'),
+      Uri.parse('${_getBasePath()}/UnityLibrary/index.html'),
     );
 
   @override
@@ -35,5 +35,11 @@ class _WebUnityWidgetViewState extends State<WebUnityWidgetView> {
   @override
   Widget build(BuildContext context) {
     return WebViewWidget(controller: _controller);
+  }
+  
+  static String _getBasePath() {
+    var prefix = Uri.base.origin+Uri.base.path;
+    if (prefix.endsWith("/")) prefix = prefix.substring(0, prefix.length - 1);
+    return prefix;
   }
 }


### PR DESCRIPTION
Currently the root path is hardcoded to Url.base.origin which is just the domain, and loses any subdirectory references.

This adds the path - it's slightly more fiddly than I'd like because Url.base.path is incosistent.. if there's a directory it ends with a slash, if there isn't it's completely empty rather than '/'.


