### PR TITLE
Remove ndkPath from generated build.gradle

### DIFF
--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -330,6 +330,7 @@ body { padding: 0; margin: 0; overflow: hidden; }
             buildText = buildText.Replace("enableSplit = true", "enable true");
             buildText = buildText.Replace("implementation fileTree(dir: 'libs', include: ['*.jar'])", "implementation(name: 'unity-classes', ext:'jar')");
             buildText = buildText.Replace(" + unityStreamingAssets.tokenize(', ')", "");
+            buildText = Regex.Replace(buildText, "ndkPath \".*\"", "");
 
             if(isPlugin)
             {


### PR DESCRIPTION
## Description

Starting Unity 2023, Unity generates build.gradle with ndkPath which contains the absolute path to the NDK. e.g:

```gradle
android {
    ndkPath "/Applications/Unity/Hub/Editor/2023.1.14f1/PlaybackEngines/AndroidPlayer/NDK"
    compileSdkVersion 33
    buildToolsVersion "32.0.0"
```

This causes the build to fail when tested on a different machine or when the ndk version is defined in the app-level _build.gradle_.

```
* What went wrong:
Execution failed for task ':unityLibrary:BuildIl2CppTask'.
> NDK is not installed
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
