### PR TITLE
[Android] Fix UnityThemeSelector error due to missing files in unityLibrary/src/android/res 

### DIFF
--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -229,8 +229,8 @@ namespace FlutterUnityIntegration.Editor
                 SetupAndroidProject();
             }
 
-            // Copy over resources from the launcher module that are used by the library
-            Copy(Path.Combine(APKPath + "/launcher/src/main/res"), Path.Combine(AndroidExportPath, "src/main/res"));
+            // Copy over resources from the launcher module that are used by the library, Avoid deleting the existing src/main/res contents.
+            Copy(Path.Combine(APKPath + "/launcher/src/main/res"), Path.Combine(AndroidExportPath, "src/main/res"), false);
 
             if (isReleaseBuild) {
                 Debug.Log($"-- Android Release Build: SUCCESSFUL --");
@@ -444,9 +444,9 @@ body { padding: 0; margin: 0; overflow: hidden; }
 
 
         //#region Other Member Methods
-        private static void Copy(string source, string destinationPath)
+        private static void Copy(string source, string destinationPath, bool clearDestination = true)
         {
-            if (Directory.Exists(destinationPath))
+            if (clearDestination && Directory.Exists(destinationPath))
                 Directory.Delete(destinationPath, true);
 
             Directory.CreateDirectory(destinationPath);

--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -32,27 +32,18 @@ namespace FlutterUnityIntegration.Editor
         public static void DoBuildAndroidLibraryDebug()
         {
             DoBuildAndroid(Path.Combine(APKPath, "unityLibrary"), false, false);
-
-            // Copy over resources from the launcher module that are used by the library
-            Copy(Path.Combine(APKPath + "/launcher/src/main/res"), Path.Combine(AndroidExportPath, "src/main/res"));
         }
 
         [MenuItem("Flutter/Export Android (Release) %&m", false, 102)]
         public static void DoBuildAndroidLibraryRelease()
         {
             DoBuildAndroid(Path.Combine(APKPath, "unityLibrary"), false, true);
-
-            // Copy over resources from the launcher module that are used by the library
-            Copy(Path.Combine(APKPath + "/launcher/src/main/res"), Path.Combine(AndroidExportPath, "src/main/res"));
         }
 
         [MenuItem("Flutter/Export Android Plugin %&p", false, 103)]
         public static void DoBuildAndroidPlugin()
         {
             DoBuildAndroid(Path.Combine(APKPath, "unityLibrary"), true, true);
-
-            // Copy over resources from the launcher module that are used by the library
-            Copy(Path.Combine(APKPath + "/launcher/src/main/res"), Path.Combine(AndroidExportPath, "src/main/res"));
         }
 
         [MenuItem("Flutter/Export IOS (Debug) %&i", false, 201)]
@@ -237,6 +228,9 @@ namespace FlutterUnityIntegration.Editor
             {
                 SetupAndroidProject();
             }
+
+            // Copy over resources from the launcher module that are used by the library
+            Copy(Path.Combine(APKPath + "/launcher/src/main/res"), Path.Combine(AndroidExportPath, "src/main/res"));
 
             if (isReleaseBuild) {
                 Debug.Log($"-- Android Release Build: SUCCESSFUL --");


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

If you export the example project for Android with Unity 2023.3.x, you will get errors related to a missing `style/UnityThemeSelector`.
This is because the file that declares this style is accidentally deleted during the export, this pull request makes sure the file is kept.


## Cause


During the unity export, the folder `unityLibrary/src/main/res` is accidentally deleted during a copy.



It first copies `unity/<project>/Builds/<name>.apk/unityLibrary` to `android/unityLibrary`.
`unityLibrary/src/main/res` now contains multiple files (may differ per Unity version)
- freeformwindow.xml
- ids.xml
- styles.xml

Then it copies `unity/<project>/Builds/<name>.apk/launcher/src/main/res`on top of that.
This copy function deletes the destination folder.
So now `unityLibrary/src/main/res` only contains:
- string.xml


The missing styles.xml file is now causing this issue.


## Error message

```
FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':app:processReleaseResources'.
> A failure occurred while executing com.android.build.gradle.internal.res.LinkApplicationAndroidResourcesTask$TaskAction
   > Android resource linking failed
     C:\Users\User\Documents\unity_widget\example\build\app\intermediates\packaged_manifests\release\AndroidManifest.xml:81: error: resource style/UnityThemeSelector (aka com.xraph.plugin.flutter_unity_widget_example:style/UnityThemeSelector) not found.
     error: failed processing manifest.


* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':app:bundleReleaseResources'.
> A failure occurred while executing com.android.build.gradle.internal.res.Aapt2ProcessResourcesRunnable
   > Android resource linking failed
     C:\Users\User\Documents\unity_widget\example\build\app\intermediates\bundle_manifest\release\AndroidManifest.xml:81: error: resource style/UnityThemeSelector (aka com.xraph.plugin.flutter_unity_widget_example:style/UnityThemeSelector) not found.
     error: failed processing manifest.


* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
==============================================================================
```




## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
