### PR TITLE
[Android] Fix Unity plugins using the AndroidJavaProxy. (mUnityPlayer error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,12 @@ android {
 2. Depending on your gradle version, you might need to make sure the `minSdkVersion` set in `android\app\build.gradle` matches the version that is set in Unity.  
 Check the **Minimum API Level** setting in the Unity player settings, and match that version.
 
-3. Fixing the MainActivity.  
-This step is needed starting from Unity 2020.3.46+, 2021.3.19+ and 2022.2.4+.  
-You need a flutter_unity_widget version that is newer than 2022.2.0 for this step.
+3. (optional) Fixing Unity plugins.  
+The Unity widget will function without this step, but some Unity plugins like ArFoundation will throw `mUnityPlayer` errors on newer Unity versions.  
+
+    This is needed starting from Unity 2020.3.46+, 2021.3.19+ and 2022.2.4+.  
+This requires a flutter_unity_widget version that is newer than 2022.2.0.  
+
 
 - 3.1. Open the `android/app/build.gradle` file and add the following:
 
@@ -194,11 +197,13 @@ You need a flutter_unity_widget version that is newer than 2022.2.0 for this ste
 +        implementation project(':flutter_unity_widget')
      }
 ```
-- 3.2. Edit your android MainAcitivity file.  
+- 3.2. Edit your android MainActivity file.  
 The default location for Flutter is `android/app/src/main/kotlin/<app identifier>/MainActivity.kt`.
 
   If you use the default flutter activity, change it to inherit `FlutterUnityActivity`:
 ```diff
+// MainActivity.kt
+
 + import com.xraph.plugin.flutter_unity_widget.FlutterUnityActivity;
 
 + class MainActivity: FlutterUnityActivity() {
@@ -208,16 +213,18 @@ The default location for Flutter is `android/app/src/main/kotlin/<app identifier
 - 3.2. (alternative) If you use a custom or modified Activity, implement the `IFlutterUnityActivity` interface instead.
 
 ```kotlin
-// only do this if your activity does not inerhit FlutterActivity
+// MainActivity.kt
+
+// only do this if your activity does not inherit FlutterActivity
 
 import com.xraph.plugin.flutter_unity_widget.IFlutterUnityActivity;
 
 class MainActivity: CustomActivity(), IFlutterUnityActivity {
-    // unity needs this mUnityPlayer property
+    // unity will try to read this mUnityPlayer property
     @JvmField 
     var mUnityPlayer: java.lang.Object? = null;
 
-    // implement this function so the FUW plugin can set mUnityPlayer
+    // implement this function so the plugin can set mUnityPlayer
     override fun setUnityPlayer(unityPlayer: java.lang.Object?) {
         mUnityPlayer = unityPlayer;
     }

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ Check the **Minimum API Level** setting in the Unity player settings, and match 
 3. (optional) Fixing Unity plugins.  
 The Unity widget will function without this step, but some Unity plugins like ArFoundation will throw `mUnityPlayer` errors on newer Unity versions.  
 
-    This is needed starting from Unity 2020.3.46+, 2021.3.19+ and 2022.2.4+.  
-This requires a flutter_unity_widget version that is newer than 2022.2.0.  
+    This is needed for Unity 2020.3.46+, 2021.3.19 - 2021.3.20 and 2022.2.4 - 2022.3.18.  
+This requires a flutter_unity_widget version that is newer than 2022.2.1.  
 
 
 - 3.1. Open the `android/app/build.gradle` file and add the following:

--- a/README.md
+++ b/README.md
@@ -183,20 +183,62 @@ android {
 2. Depending on your gradle version, you might need to make sure the `minSdkVersion` set in `android\app\build.gradle` matches the version that is set in Unity.  
 Check the **Minimum API Level** setting in the Unity player settings, and match that version.
 
-3. The Unity export script automatically sets the rest up for you. You are done with the Android setup.  
+3. Fixing the MainActivity.  
+This step is needed starting from Unity 2020.3.46+, 2021.3.19+ and 2022.2.4+.  
+You need a flutter_unity_widget version that is newer than 2022.2.0 for this step.
+
+- 3.1. Open the `android/app/build.gradle` file and add the following:
+
+```diff
+     dependencies {
++        implementation project(':flutter_unity_widget')
+     }
+```
+- 3.2. Edit your android MainAcitivity file.  
+The default location for Flutter is `android/app/src/main/kotlin/<app identifier>/MainActivity.kt`.
+
+  If you use the default flutter activity, change it to inherit `FlutterUnityActivity`:
+```diff
++ import com.xraph.plugin.flutter_unity_widget.FlutterUnityActivity;
+
++ class MainActivity: FlutterUnityActivity() {
+- class MainActivity: FlutterActivity() {
+```
+
+- 3.2. (alternative) If you use a custom or modified Activity, implement the `IFlutterUnityActivity` interface instead.
+
+```kotlin
+// only do this if your activity does not inerhit FlutterActivity
+
+import com.xraph.plugin.flutter_unity_widget.IFlutterUnityActivity;
+
+class MainActivity: CustomActivity(), IFlutterUnityActivity {
+    // unity needs this mUnityPlayer property
+    @JvmField 
+    var mUnityPlayer: java.lang.Object? = null;
+
+    // implement this function so the FUW plugin can set mUnityPlayer
+    override fun setUnityPlayer(unityPlayer: java.lang.Object?) {
+        mUnityPlayer = unityPlayer;
+    }
+}
+```
+
+
+4. The Unity export script automatically sets the rest up for you. You are done with the Android setup.  
 But if you want to manually set up the changes made by the export, continue.
   
 <details> 
 <summary> Optional manual Android setup </summary> 
 
-4. Open the *android/settings.gradle* file and change the following:
+5. Open the *android/settings.gradle* file and change the following:
 
 ```diff
 +    include ":unityLibrary"
 +    project(":unityLibrary").projectDir = file("./unityLibrary")
 ```
 
-5. Open the *android/app/build.gradle* file and change the following:
+6. Open the *android/app/build.gradle* file and change the following:
 
 ```diff
      dependencies {
@@ -204,7 +246,7 @@ But if you want to manually set up the changes made by the export, continue.
      }
 ```
 
-6. open the *android/build.gradle* file and change the following:
+7. open the *android/build.gradle* file and change the following:
 
 ```diff
 allprojects {
@@ -218,7 +260,7 @@ allprojects {
 }
 ```
 
-7. If you need to build a release package, open the *android/app/build.gradle* file and change the following:
+8. If you need to build a release package, open the *android/app/build.gradle* file and change the following:
 
 ```diff
      buildTypes {
@@ -239,13 +281,13 @@ allprojects {
 
 > The code above use the `debug` signConfig for all buildTypes, which can be changed as you well if you need specify signConfig.
 
-8. If you use `minifyEnabled true` in your *android/app/build.gradle* file, open the *android/unityLibrary/proguard-unity.txt* and change the following:
+9. If you use `minifyEnabled true` in your *android/app/build.gradle* file, open the *android/unityLibrary/proguard-unity.txt* and change the following:
 
 ```diff
 +    -keep class com.xraph.plugin.** {*;}
 ```
 
-9. If you want Unity in it's own activity as an alternative, open the *android/app/src/main/AndroidManifest.xml* and change the following:
+10. If you want Unity in it's own activity as an alternative, open the *android/app/src/main/AndroidManifest.xml* and change the following:
 
 ```diff
 +    <activity
@@ -341,7 +383,7 @@ Switch to version `4.2.2` or `4.4` to avoid this.
   There seems to be a bug where a Unity export does not include all lib files. If they are missing, use Unity to build a standalone .apk
   of your AR project, unzip the resulting apk, and copy over the missing .lib files to the `unityLibrary` module. 
   
-  8. Repeat steps 4 and 5 from the Android <b>Platform specific setup</b> (editing build.gradle and settings.gradle), replacing `unityLibrary` with `arcore_client`, `unityandroidpermissions` and `UnityARCore`.
+  8. Repeat steps 5 and 6 from the Android <b>Platform specific setup</b> (editing build.gradle and settings.gradle), replacing `unityLibrary` with `arcore_client`, `unityandroidpermissions` and `UnityARCore`.
   
   9. When using `UnityWidget` in Flutter, set `fullscreen: false` to disable fullscreen.
 

--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityActivity.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityActivity.kt
@@ -1,0 +1,27 @@
+package com.xraph.plugin.flutter_unity_widget
+
+import io.flutter.embedding.android.FlutterActivity
+
+/* 
+The following Unity versions expect the mUnityPlayer property on the main activity: 
+- 2020.3.46 or higher
+- 2021.3.19 or higher
+- 2022.2.4 or higher
+
+Unity will function without it, but many Unity plugins (like ARFoundation) will not.
+Implement FlutterUnityActivity or the interface to fix these plugins.
+*/
+
+open class FlutterUnityActivity: FlutterActivity() {
+    @JvmField
+    var mUnityPlayer: java.lang.Object? = null;
+}
+
+
+/*
+ A function that is called when initializing Unity.
+ Expected use is to set a mUnityPlayer property, just as defined in FlutterUnityActivity above.
+*/
+interface IFlutterUnityActivity {
+    fun setUnityPlayer(unityPlayer: java.lang.Object?)
+}

--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityActivity.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityActivity.kt
@@ -5,11 +5,13 @@ import io.flutter.embedding.android.FlutterActivity
 /* 
 The following Unity versions expect the mUnityPlayer property on the main activity: 
 - 2020.3.46 or higher
-- 2021.3.19 or higher
-- 2022.2.4 or higher
+- 2021.3.19 - 2021.3.20
+- 2022.2.4 - 2022.3.18
 
 Unity will function without it, but many Unity plugins (like ARFoundation) will not.
 Implement FlutterUnityActivity or the interface to fix these plugins.
+
+https://github.com/juicycleff/flutter-unity-view-widget/pull/908
 */
 
 open class FlutterUnityActivity: FlutterActivity() {

--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityPlayerUtils.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityPlayerUtils.kt
@@ -63,6 +63,17 @@ class UnityPlayerUtils {
 
             try {
                 unityPlayer = CustomUnityPlayer(activity!!, ule)
+
+                // Assign mUnityPlayer in the Activity, see FlutterUnityActivity.kt for more details
+                if(activity is FlutterUnityActivity) {
+                    (activity!! as FlutterUnityActivity)?.mUnityPlayer = (unityPlayer as java.lang.Object?);
+                } else if(activity is IFlutterUnityActivity) {
+                    (activity!! as IFlutterUnityActivity)?.setUnityPlayer(unityPlayer as java.lang.Object?);
+                } else {
+                     Log.e(LOG_TAG, "Could not set mUnityPlayer in activity");
+                }
+                
+
                 // unityPlayer!!.z = (-1).toFloat()
                 // addUnityViewToBackground(activity!!)
                 unityLoaded = true

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -60,5 +60,6 @@ flutter {
 
 dependencies {
     implementation project(':unityLibrary')
+    implementation project(':flutter_unity_widget')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/example/android/app/src/main/kotlin/com/xraph/plugin/flutter_unity_widget_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/xraph/plugin/flutter_unity_widget_example/MainActivity.kt
@@ -1,6 +1,22 @@
 package com.xraph.plugin.flutter_unity_widget_example
 
-import io.flutter.embedding.android.FlutterActivity
+import com.xraph.plugin.flutter_unity_widget.FlutterUnityActivity;
 
-class MainActivity: FlutterActivity() {
+class MainActivity: FlutterUnityActivity() {
+
 }
+
+ 
+// If you can't inherit FlutterUnityActivity directly, use the interface like this:
+/*
+import com.xraph.plugin.flutter_unity_widget.IFlutterUnityActivity;
+
+class ActivityExample: SomeActivity(), IFlutterUnityActivity {
+    @JvmField 
+    var mUnityPlayer: java.lang.Object? = null;
+
+    override fun setUnityPlayer(unityPlayer: java.lang.Object?) {
+        mUnityPlayer = unityPlayer;
+    }
+}
+*/


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Unity made changes to their AndroidJavaProxy which causes a crash when using certain packages.
This breaks popular Unity plugins like ARFoundation and Google Ads, and likely many more.

Unity expects a `mUnityPlayer` property to exist on the MainActivity, but the FlutterActivity used in Flutter apps doesn't have that property.



This change is found in the following Unity versions (and maybe more):
- 2020.3.46 or higher
- 2021.3.19 - 2021.3.20
- 2022.2.4 - 2022.3.18


For the full description and discussion see https://github.com/juicycleff/flutter-unity-view-widget/issues/836


## Error

Example of the error when the app crashes:
```
Non-fatal Exception: java.lang.Exception: AndroidJavaException : java.lang.NoSuchFieldError: no "Ljava/lang/Object;" field "mUnityPlayer" in class "Lcom/example/app/MainActivity;" or its superclasses
       at com.unity3d.player.UnityPlayer.nativeRender(com.unity3d.player.UnityPlayer)
       at com.unity3d.player.UnityPlayer.-$$Nest$mnativeRender(com.unity3d.player.UnityPlayer)
       at com.unity3d.player.UnityPlayer$C$a.handleMessage(com.unity3d.player.UnityPlayer$C$a)
       at android.os.Handler.dispatchMessage(android.os.Handler)
       at android.os.Looper.loopOnce(android.os.Looper)
       at android.os.Looper.loop(android.os.Looper)
       at com.unity3d.player.UnityPlayer$C.run(com.unity3d.player.UnityPlayer$C)
       at UnityEngine.AndroidJNISafe.CheckException(AndroidJNISafe.cs:24)
       at UnityEngine.AndroidJNISafe.GetFieldID(AndroidJNISafe.cs:87)
       at UnityEngine._AndroidJNIHelper.GetFieldID(AndroidJava.cs:1614)
       at UnityEngine.AndroidJNIHelper.GetFieldID(AndroidJNI.bindings.cs:91)
       at UnityEngine._AndroidJNIHelper.GetFieldID[ReturnType](AndroidJava.cs:1534)
       at UnityEngine.AndroidJNIHelper.GetFieldID[FieldType](AndroidJNI.bindings.cs:198)
       at UnityEngine.AndroidJavaObject._Get[FieldType](AndroidJava.cs:630)
       at UnityEngine.AndroidJavaObject.Get[FieldType](AndroidJava.cs:345)
       at UnityEngine.AndroidJNIHelper.CreateJavaProxy(AndroidJNI.bindings.cs:106)
```


## Solution


This pull request adds a new class `FlutterUnityActivity` and interface `IFlutterUnityActivity`.  
These contain a `mUnityPlayer` property that gets set by the plugin once Unity is initialized.  


This does add a manual setup step, which i've added to the readme.


I've had some users [use my branch since August 2023](https://github.com/juicycleff/flutter-unity-view-widget/issues/836#issuecomment-1684592850) and I haven't heard of any issues yet.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore

## Merging
This can be merged with a squash merge, to hide the multiple documentation commits.
