### PR TITLE
Update AR Foundation instructions and fix missing XRmanifest.androidlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,29 +329,53 @@ allprojects {
  The following setup for AR is done after making an export from Unity.
 
 
-<b>Warning: The `XR Plugin Management` package version `4.3.1 - 4.3.3` has bug that breaks Android exports. </b>
+<b>Warning: The `XR Plugin Management` package version `4.3.1 - 4.3.3` has a bug that breaks Android exports. </b>
 
 - The bug accidentally deletes your AndroidManifest.xml file after each build, resulting in a broken export.  
 Switch to version `4.2.2` or `4.4` to avoid this.  
+You might have to manually change the version in `<unity project>/Packages/manifest.json` to `"com.unity.xr.management": "4.4.0",`
 
 <details>
  <summary>:information_source: <b>AR Foundation Android</b></summary>
+  
+  1. You can check the `android/unityLibrary/libs` folder to see if AR was properly exported. It should contain files similar to `UnityARCore.aar`, `ARPresto.aar`, `arcore_client.aar` and `unityandroidpermissions.aar`.  
 
+     If your setup and export was done correctly, your project should automatically load these files.  
+     If it doesn't, check if your `android/build.gradle` file contains the `flatDir` section added in the android setup step 6.
+ 
+  2. If your `XR Plugin Management` plugin is version 4.4 or higher, Unity also exports the xrmanifest.androidlib folder.
+     Make sure to include it by adding the following line to `android/settings.gradle`
+     ```
+     include ":unityLibrary:xrmanifest.androidlib"
+     ```
+  3. With some Unity versions AR might crash at runtine with an error like:  
+   `java.lang.NoSuchFieldError: no "Ljava/lang/Object;" field "mUnityPlayer" in class`.  
+   You will need an updated plugin and modify your MainActivity to fix this.  
+   Check if [this pull request](https://github.com/juicycleff/flutter-unity-view-widget/pull/908) was merged or otherwise use that branch for your plugin for now.
+
+  4. When using UnityWidget in Flutter, set fullscreen: false to disable fullscreen.
+
+<details><summary>Legacy AR Foundation instructions</summary></summary>
+  
   7. Open the *lib/__architecture__/* folder and check if there are both *libUnityARCore.so* and *libarpresto_api.so* files.
   There seems to be a bug where a Unity export does not include all lib files. If they are missing, use Unity to build a standalone .apk
   of your AR project, unzip the resulting apk, and copy over the missing .lib files to the `unityLibrary` module. 
   
   8. Repeat steps 4 and 5 from the Android <b>Platform specific setup</b> (editing build.gradle and settings.gradle), replacing `unityLibrary` with `arcore_client`, `unityandroidpermissions` and `UnityARCore`.
   
-  9. When using `UnityWidget` in Flutter, set `fullscreen: false` to disable fullscreen.
+  
+
+</details>
+ 
 
 -----
 </details>
 
 <details>
  <summary>:information_source: <b>AR Foundation iOS</b></summary>
-7. Open the *ios/Runner/Info.plist* and change the following:
 
+1. Open the *ios/Runner/Info.plist* and add a camera usage description.  
+For example: 
 ```diff
      <dict>
 +        <key>NSCameraUsageDescription</key>

--- a/README.md
+++ b/README.md
@@ -399,8 +399,7 @@ You might have to manually change the version in `<unity project>/Packages/manif
      ```
   3. With some Unity versions AR might crash at runtine with an error like:  
    `java.lang.NoSuchFieldError: no "Ljava/lang/Object;" field "mUnityPlayer" in class`.  
-   You will need an updated plugin and modify your MainActivity to fix this.  
-   Check if [this pull request](https://github.com/juicycleff/flutter-unity-view-widget/pull/908) was merged or otherwise use that branch for your plugin for now.
+   See the Android setup step 3 on how to edit your MainActivity to fix this. 
 
   4. When using UnityWidget in Flutter, set fullscreen: false to disable fullscreen.
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ You might have to manually change the version in `<unity project>/Packages/manif
   1. You can check the `android/unityLibrary/libs` folder to see if AR was properly exported. It should contain files similar to `UnityARCore.aar`, `ARPresto.aar`, `arcore_client.aar` and `unityandroidpermissions.aar`.  
 
      If your setup and export was done correctly, your project should automatically load these files.  
-     If it doesn't, check if your `android/build.gradle` file contains the `flatDir` section added in the android setup step 6.
+     If it doesn't, check if your `android/build.gradle` file contains the `flatDir` section added in the android setup step 7.
  
   2. If your `XR Plugin Management` plugin is version 4.4 or higher, Unity also exports the xrmanifest.androidlib folder.
      Make sure to include it by adding the following line to `android/settings.gradle`

--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -536,6 +536,14 @@ project("":unityLibrary"").projectDir = file(""./unityLibrary"")
             }
 
 
+            // The XR management package might export an xrmanifest folder, also include this in settings.gradle
+            string xrmanifest = Path.Combine(APKPath, "unityLibrary", "xrmanifest.androidlib");
+            if (Directory.Exists(xrmanifest) && !settingsScript.Contains("xrmanifest.androidlib")) {
+                 settingsScript += "\ninclude \":unityLibrary:xrmanifest.androidlib\"";
+                 File.WriteAllText(settingsPath, settingsScript);
+            }
+
+
             // Sets up the project app build.gradle files correctly
             if (!Regex.IsMatch(appBuildScript, @"dependencies \{"))
             {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

If your Unity project uses `XR Plugin management` 4.4 or higher, you get an error when building on android. https://github.com/juicycleff/flutter-unity-view-widget/issues/844
```
Project with path 'xrmanifest.androidlib' could not be found in project ':unityLibrary
```

You need to add an include to settings.gradle to handle this.

## Changes
- Document including xrmanifest.androidlib in the readme.
```
include ":unityLibrary:xrmanifest.androidlib"
```
- Update outdated AR Foundation setup in the readme.
  You don't need to manually include all the .aar files in gradle anymore.
- Android export now tries to automatically include xrmanifest.androidlib in settings.gradle


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore

##
This PR is somewhat related to https://github.com/juicycleff/flutter-unity-view-widget/pull/908, as ARFoundation will crash on recent unity versions without that fix.
