### PR TITLE
Update dart sdk in pubspec to < 4.0 instead of < 3.0

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the flutter_unity_widget plugin.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ version: 2022.2.0
 homepage: https://github.com/juicycleff/flutter-unity-view-widget/tree/master
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
+  sdk: ">=2.16.0 <4.0.0"
   flutter: ">=3.3.0"
 
 dependencies:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The pubspec.yaml files for the plugin and example have outdated contraints on the dart sdk.
- Example  `>=2.12.0 <3.0.0`  
- Plugin `>=2.16.0 <3.0.0`

Compare that to the Dart version of recent Flutter releases:
- Flutter 3.16.5, Dart 3.2.3
- Flutter 3.16,0, Dart 3.2.0
- Flutter 3.13.9, Dart 3.1.5
- Flutter 3.10.6, Dart 3.0.6
- Flutter 3.10.0, Dart 3.0.0

Somehow i'm not getting any errors on installing or building the package, but I won't be surprised if this will lead to errors in the future.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
