### PR TITLE
[Android] Fix touch input with the new input system.

### DIFF
--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/CustomUnityPlayer.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/CustomUnityPlayer.kt
@@ -46,7 +46,19 @@ class CustomUnityPlayer(context: Activity, upl: IUnityPlayerLifecycleEvents?) : 
         if (event == null) return false
 
         event.source = InputDevice.SOURCE_TOUCHSCREEN
-        return super.onTouchEvent(event)
+        
+        // true for Flutter Virtual Display, false for Hybrid composition.
+        if (event.deviceId == 0) {        
+            /* 
+              Flutter creates a touchscreen motion event with deviceId 0. (https://github.com/flutter/flutter/blob/34b454f42dd6f8721dfe43fc7de5d215705b5e52/packages/flutter/lib/src/services/platform_views.dart#L639)
+              Unity's new Input System package does not detect these touches, copy the motion event to change the immutable deviceId.
+            */
+            val modifiedEvent = event.copy(deviceId = -1)
+            event.recycle()
+            return super.onTouchEvent(modifiedEvent)
+        } else {
+            return super.onTouchEvent(event)
+        }
     }
 
 }

--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/utils/CopyMotionEvent.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/utils/CopyMotionEvent.kt
@@ -1,0 +1,56 @@
+// source https://gist.github.com/sebschaef/b803da53217c88e8c691aeed08602193
+
+package com.xraph.plugin.flutter_unity_widget
+
+import android.view.MotionEvent
+
+/*
+  Copies a MotionEvent. Use the named parameters to modify immutable properties.
+  Don't forget to recycle the original event if it is not used anymore.
+*/
+fun MotionEvent.copy(
+    downTime: Long = getDownTime(),
+    eventTime: Long = getEventTime(),
+    action: Int = getAction(),
+    pointerCount: Int = getPointerCount(),
+    pointerProperties: Array<MotionEvent.PointerProperties>? =
+        (0 until getPointerCount())
+            .map { index ->
+                MotionEvent.PointerProperties().also { pointerProperties ->
+                    getPointerProperties(index, pointerProperties)
+                }
+            }
+            .toTypedArray(),
+    pointerCoords: Array<MotionEvent.PointerCoords>? =
+        (0 until getPointerCount())
+            .map { index ->
+                MotionEvent.PointerCoords().also { pointerCoords ->
+                    getPointerCoords(index, pointerCoords)
+                }
+            }
+            .toTypedArray(),
+    metaState: Int = getMetaState(),
+    buttonState: Int = getButtonState(),
+    xPrecision: Float = getXPrecision(),
+    yPrecision: Float = getYPrecision(),
+    deviceId: Int = getDeviceId(),
+    edgeFlags: Int = getEdgeFlags(),
+    source: Int = getSource(),
+    flags: Int = getFlags()
+): MotionEvent =
+    MotionEvent.obtain(
+        downTime,
+        eventTime,
+        action,
+        pointerCount,
+        pointerProperties,
+        pointerCoords,
+        metaState,
+        buttonState,
+        xPrecision,
+        yPrecision,
+        deviceId,
+        edgeFlags,
+        source,
+        flags
+    )


### PR DESCRIPTION
## Description
Fixes #766

Unity code or UI that uses touch events using the (new) Input System package doesn't work when using this widget with the default settings on Android.  

Flutter has 2 embedding modes that work for this plugin on Android:
- Virtual Display  (default), `useAndroidViewSurface: false`
- Hybrid Composition, `useAndroidViewSurface: true`

Touch input using the new input system currently works in HC mode, but not in VD mode.  


This PR adds a workaround to make touch input work for both modes when using the new Input System.


## Context
After logging both implementations I noticed that touch events using HC have a positive integer `deviceId`, which can be anything for different devices. 
VD touch events will always have a deviceId of 0.

According to the [android docs](https://developer.android.com/reference/android/view/MotionEvent#getDeviceId())
>  An id of zero indicates that the event didn't come from a physical device and maps to the default keymap. The other numbers are arbitrary and you shouldn't depend on the values.

My tests on multiple real devices and emulators showed me values of 2, 3, 4, 12 and 14.
## Fix
In `onToucEvent` change the deviceId of a MotionEvent if it is 0.  
I chose `-1` as that works in Unity and seems unlikely to conflict with any actual hardware.  

Changing the deviceId does not make any difference to the old input system, which likely ignores it anyway.  

## Testing
- Use the example Unity project.
- Install the `Input System` package using the package manager.
- In the player settings, set `Active Input Handling` to `Input System Package (New)`
- On the EventSystem in the scene, make sure the new input system is used. 
![eventsystem](https://github.com/learntoflutter/flutter_embed_unity/assets/11444698/690e79ca-3c07-4794-9f3a-bf0b517dcb09)
- Run the flutter app and select **Simple Unity Demo**.
- Try pressing the UI buttons.
- It doesn't work without this fix.  

### Unity
So far I've tested this on Unity 2022.3.21, 2021.3.35 and 2019.4.40.

### Android
It works on various Android devices and versions:
- Samsung S20FE, Android 13
- Samsung S8, Android 9,
- Wilefox Swift, Android 7,
- Samsung J5 Android 6,

https://github.com/learntoflutter/flutter_embed_unity/pull/17#issuecomment-1995264765
> I've tested using 2022.3.20 using the devices I have available, all looks good:
>
>    Pixel 2
>    Galaxy S22
>    Galaxy Tab A7
>    Xiaomi 10T Pro


## Video
Comparison of touch input before and after this fix. Using `useAndroidViewSurface: false` and the new input system.
<table>
<tr>
<td>


https://github.com/juicycleff/flutter-unity-view-widget/assets/11444698/fa9c2644-e014-4b67-a580-5cdd15f5add5




</td>

<td>


https://github.com/juicycleff/flutter-unity-view-widget/assets/11444698/9055958e-154c-4ff4-af6b-45eca95168b9




</td>
</tr>
</table>



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
