### PR TITLE
Add ios privacy manifest

### DIFF
--- a/ios/Resources/PrivacyInfo.xcprivacy
+++ b/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/ios/flutter_unity_widget.podspec
+++ b/ios/flutter_unity_widget.podspec
@@ -27,4 +27,6 @@ A new Flutter plugin.
      'FRAMEWORK_SEARCH_PATHS' => '"${PODS_ROOT}/../UnityLibrary" "${PODS_ROOT}/../.symlinks/flutter/ios-release" "${PODS_CONFIGURATION_BUILD_DIR}"',
      'OTHER_LDFLAGS' => '$(inherited) -framework UnityFramework ${PODS_LIBRARIES}'
   }
+  
+  s.resource_bundles = {'flutter_unity_widget_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
## Description

Starting May 1 2024, Apple requires apps and some 3rd party frameworks to [include a privacy manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api) that documents usage of certains APIs.

##
After both a manual search and running [this scanner](https://github.com/Wooder/ios_17_required_reason_api_scanner), this plugin doesn't appear to be using any of these APIs directly.

However Unity uses multiple and is required to provide these manifests.
These are included in builds and exports as of 2021.3.35f1 and 2022.3.18f1, see the [unity docs](https://docs.unity3d.com/2021.3/Documentation/Manual/apple-privacy-manifest-policy.html).

Just as a precaution, this PR adds an empty manifest for the plugin code.
Providing a manifest will also make it easier for any user that has to manually check all their used plugins after failing a future Apple review.

##
For easier maintenance, I've used the same podspec approach as the Flutter plugins in github.com/flutter/packages.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
