### PR TITLE
Add gradle namespace & update example gradle versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Pending (master branch only)
 * [Android] Fix touch detection when using Unity's New Input System. [#938](https://github.com/juicycleff/flutter-unity-view-widget/pull/938)
 * [Android] Workaround for mUnityplayer error in Unity plugins using the AndroidJavaProxy. [#908](https://github.com/juicycleff/flutter-unity-view-widget/pull/908)
+* [Android] Add namespace for Android gradle plugin (AGP) 8 compatibility.
 
 ## 2022.2.1
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.6.20'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
 
         // DO NOT MODIFY
         // BUILD_ADD_UNITY_LIBS
@@ -34,6 +34,11 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 29
+
+    // backwards compatible for old gradle versions without namespace
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.xraph.plugin.flutter_unity_widget'
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -27,6 +27,8 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 34
+    
+    namespace 'com.xraph.plugin.flutter_unity_widget_example'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -39,8 +39,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.xraph.plugin.flutter_unity_widget_example"
-        minSdkVersion 28
-        targetSdkVersion 31
+        minSdkVersion 28  // >= unity minSdk in player settings
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,13 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.8.22'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        // Unity recommended gradle version https://docs.unity3d.com/Manual/android-gradle-overview.html (higher versions do often work)
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -19,7 +20,7 @@ allprojects {
         }
 
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the flutter_unity_widget plugin.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.0

--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -332,6 +332,14 @@ body { padding: 0; margin: 0; overflow: hidden; }
             buildText = buildText.Replace(" + unityStreamingAssets.tokenize(', ')", "");
             buildText = Regex.Replace(buildText, "ndkPath \".*\"", "");
 
+            // check for namespace definition (Android gradle plugin 8+), add a backwards compatible version if it is missing.
+            if(!buildText.Contains("namespace")) 
+            {
+                buildText = buildText.Replace("compileOptions {",
+                    "if (project.android.hasProperty(\"namespace\")) {\n        namespace 'com.unity3d.player'\n    }\n\n    compileOptions {"
+                );
+            }
+
             if(isPlugin)
             {
                 buildText = Regex.Replace(buildText, @"implementation\(name: 'androidx.* ext:'aar'\)", "\n");


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

- Namespaces for Android gradle pugin 8 compatibility (from https://github.com/juicycleff/flutter-unity-view-widget/pull/807)
- Update gradle & targetSdk versions in the example (like in https://github.com/juicycleff/flutter-unity-view-widget/pull/893)
- Replace deprecated jcenter() with mavenCentral()

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
