### PR TITLE
Add experimental Unity 6000 implementation for Android.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## Pending (master branch only)
+## Pending (experimental/unity_6000 branch)
+6000.0.0-alpha
+
+**Breaking changes**
+* Android now requires an export from Unity 6000. For Unity 2019.3-2022.3 use the latest 2022.x plugin.
+* This plugin now requires Java 17 and Gradle 8.x
+
+## Pending (forked from master branch)
 * [Android] Fix touch detection when using Unity's New Input System. [#938](https://github.com/juicycleff/flutter-unity-view-widget/pull/938)
 * [Android] Workaround for mUnityplayer error in Unity plugins using the AndroidJavaProxy. [#908](https://github.com/juicycleff/flutter-unity-view-widget/pull/908)
 * [Android] Add namespace for Android gradle plugin (AGP) 8 compatibility.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 34
 
     // backwards compatible for old gradle versions without namespace
     if (project.android.hasProperty("namespace")) {
@@ -44,15 +44,15 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 23
     }
     lintOptions {
         disable 'InvalidPackage'
     }
 
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 

--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/CustomFrameLayout.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/CustomFrameLayout.kt
@@ -1,0 +1,50 @@
+package com.xraph.plugin.flutter_unity_widget
+
+import android.annotation.SuppressLint
+import android.util.Log
+import android.view.InputDevice
+import android.view.MotionEvent
+import com.xraph.plugin.flutter_unity_widget.UnityPlayerUtils
+import android.content.Context
+import android.content.res.Configuration
+import android.widget.FrameLayout
+
+// These functions used to be in CustomUnityPlayer as UnityPlayer used to extend FrameLayout in Unity < 2023.
+// We now use these on FlutterUnityWidgetController's framelayout, which is 1 parent up in the hierarchy.
+
+
+public class CustomFrameLayout : FrameLayout  {
+
+    constructor(context: Context) : super(context)
+
+
+    companion object {
+        internal const val LOG_TAG = "CustomUnityFrameLayout"
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration?) {
+        Log.i(LOG_TAG, "ORIENTATION CHANGED")
+        super.onConfigurationChanged(newConfig)
+    }
+
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        // Log.i(LOG_TAG, "dispatchTouch")
+        event.source = InputDevice.SOURCE_TOUCHSCREEN
+
+        // instead of modifying the event in Unity onTouchEvent, intercept it before Unity gets it.
+
+         // true for Flutter Virtual Display, false for Hybrid composition.
+        if (event.deviceId == 0) {        
+             
+            //  Flutter creates a touchscreen motion event with deviceId 0. (https://github.com/flutter/flutter/blob/34b454f42dd6f8721dfe43fc7de5d215705b5e52/packages/flutter/lib/src/services/platform_views.dart#L639)
+            //  Unity's new Input System package does not detect these touches, copy the motion event to change the immutable deviceId.
+            
+            val modifiedEvent = event.copy(deviceId = -1)
+            event.recycle()
+            return super.dispatchTouchEvent(modifiedEvent)
+        } else {
+            return super.dispatchTouchEvent(event)
+        }
+    }
+
+}

--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/CustomUnityPlayer.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/CustomUnityPlayer.kt
@@ -4,61 +4,15 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.res.Configuration
 import android.util.Log
-import android.view.InputDevice
-import android.view.MotionEvent
 import com.unity3d.player.IUnityPlayerLifecycleEvents
-import com.unity3d.player.UnityPlayer
+import com.unity3d.player.UnityPlayerForActivityOrService
 
 @SuppressLint("NewApi")
-class CustomUnityPlayer(context: Activity, upl: IUnityPlayerLifecycleEvents?) : UnityPlayer(context, upl) {
+class CustomUnityPlayer(context: Activity, upl: IUnityPlayerLifecycleEvents?) : UnityPlayerForActivityOrService(context, upl) {
 
     companion object {
         internal const val LOG_TAG = "CustomUnityPlayer"
     }
 
-    override fun onConfigurationChanged(newConfig: Configuration?) {
-        Log.i(LOG_TAG, "ORIENTATION CHANGED")
-        super.onConfigurationChanged(newConfig)
-    }
-
-    override fun onAttachedToWindow() {
-        Log.i(LOG_TAG, "onAttachedToWindow")
-        super.onAttachedToWindow()
-        UnityPlayerUtils.resume()
-        UnityPlayerUtils.pause()
-        UnityPlayerUtils.resume()
-    }
-
-    override fun onDetachedFromWindow() {
-        Log.i(LOG_TAG, "onDetachedFromWindow")
-        // todo: fix more than one unity view, don't add to background.
-//        UnityPlayerUtils.addUnityViewToBackground()
-        super.onDetachedFromWindow()
-    }
-
-    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
-        ev.source = InputDevice.SOURCE_TOUCHSCREEN
-        return super.dispatchTouchEvent(ev)
-    }
-
-    @SuppressLint("ClickableViewAccessibility")
-    override fun onTouchEvent(event: MotionEvent?): Boolean{
-        if (event == null) return false
-
-        event.source = InputDevice.SOURCE_TOUCHSCREEN
-        
-        // true for Flutter Virtual Display, false for Hybrid composition.
-        if (event.deviceId == 0) {        
-            /* 
-              Flutter creates a touchscreen motion event with deviceId 0. (https://github.com/flutter/flutter/blob/34b454f42dd6f8721dfe43fc7de5d215705b5e52/packages/flutter/lib/src/services/platform_views.dart#L639)
-              Unity's new Input System package does not detect these touches, copy the motion event to change the immutable deviceId.
-            */
-            val modifiedEvent = event.copy(deviceId = -1)
-            event.recycle()
-            return super.onTouchEvent(modifiedEvent)
-        } else {
-            return super.onTouchEvent(event)
-        }
-    }
-
+    // former FrameLayout override functions moved to CustomFrameLayout and UnityPlayerUtils (unityAttachListener).
 }

--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetController.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetController.kt
@@ -45,7 +45,7 @@ class FlutterUnityWidgetController(
     private val methodChannel: MethodChannel
 
     private var methodChannelResult: MethodChannel.Result? = null
-    private var view: FrameLayout
+    private var view: CustomFrameLayout
     private var disposed: Boolean = false
     private var attached: Boolean = false
     private var loadedCallbackPending: Boolean = false
@@ -56,7 +56,7 @@ class FlutterUnityWidgetController(
         var tempContext = UnityPlayerUtils.activity as Context
         if (context != null) tempContext = context
         // set layout view
-        view = FrameLayout(tempContext)
+        view = CustomFrameLayout(tempContext)
         view.setBackgroundColor(Color.TRANSPARENT)
 
         // setup method channel
@@ -331,15 +331,15 @@ class FlutterUnityWidgetController(
 
 
     private fun attachToView() {
-        if (UnityPlayerUtils.unityPlayer == null) return
+        if (UnityPlayerUtils.unityFrameLayout == null) return
         Log.d(LOG_TAG, "Attaching unity to view")
 
-        if (UnityPlayerUtils.unityPlayer!!.parent != null) {
-            (UnityPlayerUtils.unityPlayer!!.parent as ViewGroup).removeView(UnityPlayerUtils.unityPlayer)
+        if (UnityPlayerUtils.unityFrameLayout!!.parent != null) {
+            (UnityPlayerUtils.unityFrameLayout!!.parent as ViewGroup).removeView(UnityPlayerUtils.unityFrameLayout)
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            UnityPlayerUtils.unityPlayer!!.z = -1f
+            UnityPlayerUtils.unityFrameLayout!!.z = -1f
         }
 
         // add unity to view
@@ -356,7 +356,7 @@ class FlutterUnityWidgetController(
     }
 
     fun reattachToView() {
-        if (UnityPlayerUtils.unityPlayer!!.parent != view) {
+        if (UnityPlayerUtils.unityFrameLayout!!.parent != view) {
             this.attachToView()
             Handler(Looper.getMainLooper()).post {
                 methodChannel.invokeMethod("events#onViewReattached", null)

--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/OverrideUnityActivity.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/OverrideUnityActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.WindowManager
 import com.unity3d.player.UnityPlayerActivity
+import com.unity3d.player.UnityPlayerForActivityOrService
 import java.util.Objects
 
 class OverrideUnityActivity : UnityPlayerActivity() {
@@ -26,7 +27,7 @@ class OverrideUnityActivity : UnityPlayerActivity() {
     }
 
     private fun quitPlayer() {
-        mUnityPlayer?.quit()
+        mUnityPlayer?.destroy() // unity 2023+ has no quit
     }
 
     private fun showMainActivity() {
@@ -42,7 +43,8 @@ class OverrideUnityActivity : UnityPlayerActivity() {
 
     override fun onLowMemory() {
         super.onLowMemory()
-        mUnityPlayer?.lowMemory()
+        // copied from Unity 2023 UnityPlayerForActivityOrService onLowMemory()
+        mUnityPlayer.onTrimMemory(UnityPlayerForActivityOrService.MemoryUsage.Critical);
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -30,6 +30,11 @@ android {
     
     namespace 'com.xraph.plugin.flutter_unity_widget_example'
 
+     compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.22'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         // Unity recommended gradle version https://docs.unity3d.com/Manual/android-gradle-overview.html (higher versions do often work)
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:8.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip

--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -208,7 +208,10 @@ namespace FlutterUnityIntegration.Editor
                 // remove this line if you don't use a debugger and you want to speed up the flutter build
                 playerOptions.options = BuildOptions.AllowDebugging | BuildOptions.Development;
             }
-            #if UNITY_2022_1_OR_NEWER
+            #if UNITY_6000_0_OR_NEWER
+                PlayerSettings.SetIl2CppCompilerConfiguration(UnityEditor.Build.NamedBuildTarget.Android, isReleaseBuild ? Il2CppCompilerConfiguration.Release : Il2CppCompilerConfiguration.Debug);
+                PlayerSettings.SetIl2CppCodeGeneration(UnityEditor.Build.NamedBuildTarget.Android, UnityEditor.Build.Il2CppCodeGeneration.OptimizeSize);
+            #elif UNITY_2022_1_OR_NEWER
                 PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.Android, isReleaseBuild ? Il2CppCompilerConfiguration.Release : Il2CppCompilerConfiguration.Debug);
                 PlayerSettings.SetIl2CppCodeGeneration(UnityEditor.Build.NamedBuildTarget.Android, UnityEditor.Build.Il2CppCodeGeneration.OptimizeSize);
             #elif UNITY_2021_2_OR_NEWER
@@ -216,6 +219,11 @@ namespace FlutterUnityIntegration.Editor
                 EditorUserBuildSettings.il2CppCodeGeneration = UnityEditor.Build.Il2CppCodeGeneration.OptimizeSize;
             #endif
 
+
+#if UNITY_ANDROID && UNITY_6000_0_OR_NEWER
+            UnityEditor.Android.UserBuildSettings.DebugSymbols.level = isReleaseBuild ? Unity.Android.Types.DebugSymbolLevel.None : Unity.Android.Types.DebugSymbolLevel.SymbolTable;
+            UnityEditor.Android.UserBuildSettings.DebugSymbols.format = Unity.Android.Types.DebugSymbolFormat.LegacyExtensions;
+#endif
             // Switch to Android standalone build.
             EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.Android, BuildTarget.Android);
             // build addressable
@@ -226,6 +234,13 @@ namespace FlutterUnityIntegration.Editor
                 throw new Exception("Build failed");
 
             Copy(buildPath, AndroidExportPath);
+
+            // Unity 6000 shared folder
+            string sharedPath = Path.Combine(APKPath, "shared");
+            if (Directory.Exists(sharedPath)) 
+            {
+                Copy(sharedPath, Path.Combine(AndroidExportPath, "shared"));
+            }
 
             // Modify build.gradle
             ModifyAndroidGradle(isPlugin);
@@ -332,6 +347,10 @@ body { padding: 0; margin: 0; overflow: hidden; }
             buildText = buildText.Replace(" + unityStreamingAssets.tokenize(', ')", "");
             buildText = Regex.Replace(buildText, "ndkPath \".*\"", "");
 
+            // Untiy 6000, handle ../shared/
+            buildText = Regex.Replace(buildText, @"\.\./shared/", "./shared/");
+            
+
             // check for namespace definition (Android gradle plugin 8+), add a backwards compatible version if it is missing.
             if(!buildText.Contains("namespace")) 
             {
@@ -404,7 +423,10 @@ body { padding: 0; margin: 0; overflow: hidden; }
                 EditorUserBuildSettings.iOSBuildConfigType = iOSBuildType.Release;
             #endif
 
-            #if UNITY_2022_1_OR_NEWER
+            #if UNITY_6000_0_OR_NEWER
+                PlayerSettings.SetIl2CppCompilerConfiguration(UnityEditor.Build.NamedBuildTarget.Android, isReleaseBuild ? Il2CppCompilerConfiguration.Release : Il2CppCompilerConfiguration.Debug);
+                PlayerSettings.SetIl2CppCodeGeneration(UnityEditor.Build.NamedBuildTarget.Android, UnityEditor.Build.Il2CppCodeGeneration.OptimizeSize);
+            #elif UNITY_2022_1_OR_NEWER
                 PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.iOS, isReleaseBuild ? Il2CppCompilerConfiguration.Release : Il2CppCompilerConfiguration.Debug);
                 PlayerSettings.SetIl2CppCodeGeneration(UnityEditor.Build.NamedBuildTarget.iOS, UnityEditor.Build.Il2CppCodeGeneration.OptimizeSize);
             #elif UNITY_2021_2_OR_NEWER

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_unity_widget
 description: Flutter Unity 3D widget for embedding Unity game scenes in flutter. This library now supports Unity as a Library.
-version: 2022.2.1
+version: 6000.0.0-alpha
 #authors:
 #  - Rex Raphael <rex.raphael@outlook.com>
 #  - Thomas Stockx <thomas@stockxit.com>


### PR DESCRIPTION
This PR merges into the branch `experimental/unity_6000` to allow people to test this without affecting the main plugin in master.

## Description
Unity 2023.3 turned into 6000 preview, which will eventually become the next LTS version.
For ios and web you will likely be able to  build using the existing 2022.x plugin. 
However Android had some breaking changes in Unity 2023.1.


This PR is a base implementation for supporting Unity 6000 on Android.
For now this is in a separate branch from master for testing.

### Fixed changes in the Unity 6000  android export
- Unity 2023+ makes the `UnityPlayer` class abstract and exposes `UnityPlayerForServiceOrActivity` instead.
   UnityPlayer no longer extends `FrameLayout` which breaks some overrides.
- The exported `UnityLibrary/build.gradle` now imports a gradle file from a `.../shared` folder.
- Gradle versions are updated to 8.x
- Java is updated to 17

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
