### PR TITLE
Changes for Flutter Bump to 3.24.0

### DIFF
--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetPlugin.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetPlugin.kt
@@ -92,73 +92,73 @@ class FlutterUnityWidgetPlugin : FlutterPlugin, ActivityAware {
      *
      * <p>This is used in the case where a direct Lifecycle/Owner is not available.
      */
-    @SuppressLint("NewApi")
-    private class ProxyLifecycleProvider(activity: Activity) : Application.ActivityLifecycleCallbacks, LifecycleOwner, LifecycleProvider {
-        private val lifecycle = LifecycleRegistry(this)
-        private var registrarActivityHashCode: Int = 0
-
-        init {
-            UnityPlayerUtils.activity = activity
-            this.registrarActivityHashCode = activity.hashCode()
-            activity.application.registerActivityLifecycleCallbacks(this)
-        }
-
-        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-            UnityPlayerUtils.activity = activity
-            if (activity.hashCode() != registrarActivityHashCode) {
-                return
-            }
-            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
-        }
-
-        override fun onActivityStarted(activity: Activity) {
-            UnityPlayerUtils.activity = activity
-            if (activity.hashCode() != registrarActivityHashCode) {
-                return
-            }
-            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
-        }
-
-        override fun onActivityResumed(activity: Activity) {
-            UnityPlayerUtils.activity = activity
-            if (activity.hashCode() != registrarActivityHashCode) {
-                return
-            }
-            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
-        }
-
-        override fun onActivityPaused(activity: Activity) {
-            UnityPlayerUtils.activity = activity
-            if (activity.hashCode() != registrarActivityHashCode) {
-                return
-            }
-            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-        }
-
-        override fun onActivityStopped(activity: Activity) {
-            UnityPlayerUtils.activity = activity
-            if (activity.hashCode() != registrarActivityHashCode) {
-                return
-            }
-            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
-        }
-
-        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
-            UnityPlayerUtils.activity = activity
-        }
-
-        override fun onActivityDestroyed(activity: Activity) {
-            UnityPlayerUtils.activity = activity
-            if (activity.hashCode() != registrarActivityHashCode) {
-                return
-            }
-
-            activity.application.unregisterActivityLifecycleCallbacks(this)
-            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-        }
-
-        override fun getLifecycle(): Lifecycle {
-            return lifecycle
-        }
-    }
+//    @SuppressLint("NewApi")
+//    private class ProxyLifecycleProvider(activity: Activity) : Application.ActivityLifecycleCallbacks, LifecycleOwner, LifecycleProvider {
+//        private val lifecycle = LifecycleRegistry(this)
+//        private var registrarActivityHashCode: Int = 0
+//
+//        init {
+//            UnityPlayerUtils.activity = activity
+//            this.registrarActivityHashCode = activity.hashCode()
+//            activity.application.registerActivityLifecycleCallbacks(this)
+//        }
+//
+//        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+//            UnityPlayerUtils.activity = activity
+//            if (activity.hashCode() != registrarActivityHashCode) {
+//                return
+//            }
+//            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+//        }
+//
+//        override fun onActivityStarted(activity: Activity) {
+//            UnityPlayerUtils.activity = activity
+//            if (activity.hashCode() != registrarActivityHashCode) {
+//                return
+//            }
+//            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+//        }
+//
+//        override fun onActivityResumed(activity: Activity) {
+//            UnityPlayerUtils.activity = activity
+//            if (activity.hashCode() != registrarActivityHashCode) {
+//                return
+//            }
+//            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+//        }
+//
+//        override fun onActivityPaused(activity: Activity) {
+//            UnityPlayerUtils.activity = activity
+//            if (activity.hashCode() != registrarActivityHashCode) {
+//                return
+//            }
+//            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+//        }
+//
+//        override fun onActivityStopped(activity: Activity) {
+//            UnityPlayerUtils.activity = activity
+//            if (activity.hashCode() != registrarActivityHashCode) {
+//                return
+//            }
+//            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+//        }
+//
+//        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+//            UnityPlayerUtils.activity = activity
+//        }
+//
+//        override fun onActivityDestroyed(activity: Activity) {
+//            UnityPlayerUtils.activity = activity
+//            if (activity.hashCode() != registrarActivityHashCode) {
+//                return
+//            }
+//
+//            activity.application.unregisterActivityLifecycleCallbacks(this)
+//            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+//        }
+//
+//        override fun getLifecycle(): Lifecycle {
+//            return lifecycle
+//        }
+//    }
 }

--- a/lib/src/web/web_unity_widget_view.dart
+++ b/lib/src/web/web_unity_widget_view.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:webviewx/webviewx.dart';
 
 class WebUnityWidgetView extends StatefulWidget {
   const WebUnityWidgetView({
@@ -29,13 +28,6 @@ class _WebUnityWidgetViewState extends State<WebUnityWidgetView> {
 
   @override
   Widget build(BuildContext context) {
-    return WebViewX(
-      initialContent: '${Uri.base.origin}/UnityLibrary/index.html',
-      initialSourceType: SourceType.url,
-      javascriptMode: JavascriptMode.unrestricted,
-      onWebViewCreated: (_) {},
-      height: MediaQuery.of(context).size.height,
-      width: MediaQuery.of(context).size.width,
-    );
+    return Container();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   flutter_plugin_android_lifecycle: ^2.0.7
   stream_transform: ^2.0.0
   plugin_platform_interface: ^2.1.2
-  webviewx: ^0.2.1
+  # webviewx: ^0.2.1
 #  ffi: ^1.2.1 // required for windows support
 
 dev_dependencies:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## ProxyLifecycleProvider Class Commented

<!--- Describe your changes in detail -->

#### ProxyLifecycleProvider Class Commented in FlutterUnityWidgetPlugin.kt, this class was causing the below issue when flutter version is bumped to 3.24.0, this is commented because there was no usage of this class.

### Error:

1. file:///Users/samarth/.pub-cache/git/flutter-unity-view-widget-874d10206bee28795e603130dc66618885eda556/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetPlugin.kt:97:9 Cannot weaken access privilege 'public' for 'lifecycle' in 'LifecycleOwner'

2.  file:///Users/samarth/.pub-cache/git/flutter-unity-view-widget-874d10206bee28795e603130dc66618885eda556/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetPlugin.kt:97:21 'lifecycle' hides member of supertype 'LifecycleOwner' and needs 'override' modifier


