### PR TITLE
Fix Flutter 3.24 kotlin compilation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * [Android] Fix touch detection when using Unity's New Input System. [#938](https://github.com/juicycleff/flutter-unity-view-widget/pull/938)
 * [Android] Workaround for mUnityplayer error in Unity plugins using the AndroidJavaProxy. [#908](https://github.com/juicycleff/flutter-unity-view-widget/pull/908)
 * [Android] Add namespace for Android gradle plugin (AGP) 8 compatibility.
+* [Android] Fix kotlin compilation error with Flutter 3.24 and newer. [#973](https://github.com/juicycleff/flutter-unity-view-widget/issues/973)
 
 ## 2022.2.1
 

--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetPlugin.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetPlugin.kt
@@ -87,78 +87,80 @@ class FlutterUnityWidgetPlugin : FlutterPlugin, ActivityAware {
     }
 
     /**
+     * [August 2024 UPDATE] This unused class was disabled to fix compilation errors in Flutter 3.24.
+     *
      * This class provides a {@link LifecycleOwner} for the activity driven by {@link
      * ActivityLifecycleCallbacks}.
      *
      * <p>This is used in the case where a direct Lifecycle/Owner is not available.
      */
-    @SuppressLint("NewApi")
-    private class ProxyLifecycleProvider(activity: Activity) : Application.ActivityLifecycleCallbacks, LifecycleOwner, LifecycleProvider {
-        private val lifecycle = LifecycleRegistry(this)
-        private var registrarActivityHashCode: Int = 0
-
-        init {
-            UnityPlayerUtils.activity = activity
-            this.registrarActivityHashCode = activity.hashCode()
-            activity.application.registerActivityLifecycleCallbacks(this)
-        }
-
-        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-            UnityPlayerUtils.activity = activity
-            if (activity.hashCode() != registrarActivityHashCode) {
-                return
-            }
-            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
-        }
-
-        override fun onActivityStarted(activity: Activity) {
-            UnityPlayerUtils.activity = activity
-            if (activity.hashCode() != registrarActivityHashCode) {
-                return
-            }
-            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
-        }
-
-        override fun onActivityResumed(activity: Activity) {
-            UnityPlayerUtils.activity = activity
-            if (activity.hashCode() != registrarActivityHashCode) {
-                return
-            }
-            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
-        }
-
-        override fun onActivityPaused(activity: Activity) {
-            UnityPlayerUtils.activity = activity
-            if (activity.hashCode() != registrarActivityHashCode) {
-                return
-            }
-            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-        }
-
-        override fun onActivityStopped(activity: Activity) {
-            UnityPlayerUtils.activity = activity
-            if (activity.hashCode() != registrarActivityHashCode) {
-                return
-            }
-            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
-        }
-
-        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
-            UnityPlayerUtils.activity = activity
-        }
-
-        override fun onActivityDestroyed(activity: Activity) {
-            UnityPlayerUtils.activity = activity
-            if (activity.hashCode() != registrarActivityHashCode) {
-                return
-            }
-
-            activity.application.unregisterActivityLifecycleCallbacks(this)
-            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-        }
-
-        override fun getLifecycle(): Lifecycle {
-            return lifecycle
-        }
-    }
+//    @SuppressLint("NewApi")
+//    private class ProxyLifecycleProvider(activity: Activity) : Application.ActivityLifecycleCallbacks, LifecycleOwner, LifecycleProvider {
+//        private val lifecycle = LifecycleRegistry(this)
+//        private var registrarActivityHashCode: Int = 0
+//
+//        init {
+//            UnityPlayerUtils.activity = activity
+//            this.registrarActivityHashCode = activity.hashCode()
+//            activity.application.registerActivityLifecycleCallbacks(this)
+//        }
+//
+//        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+//            UnityPlayerUtils.activity = activity
+//            if (activity.hashCode() != registrarActivityHashCode) {
+//                return
+//            }
+//            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+//        }
+//
+//        override fun onActivityStarted(activity: Activity) {
+//            UnityPlayerUtils.activity = activity
+//            if (activity.hashCode() != registrarActivityHashCode) {
+//                return
+//            }
+//            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+//        }
+//
+//        override fun onActivityResumed(activity: Activity) {
+//            UnityPlayerUtils.activity = activity
+//            if (activity.hashCode() != registrarActivityHashCode) {
+//                return
+//            }
+//            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+//        }
+//
+//        override fun onActivityPaused(activity: Activity) {
+//            UnityPlayerUtils.activity = activity
+//            if (activity.hashCode() != registrarActivityHashCode) {
+//                return
+//            }
+//            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+//        }
+//
+//        override fun onActivityStopped(activity: Activity) {
+//            UnityPlayerUtils.activity = activity
+//            if (activity.hashCode() != registrarActivityHashCode) {
+//                return
+//            }
+//            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+//        }
+//
+//        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+//            UnityPlayerUtils.activity = activity
+//        }
+//
+//        override fun onActivityDestroyed(activity: Activity) {
+//            UnityPlayerUtils.activity = activity
+//            if (activity.hashCode() != registrarActivityHashCode) {
+//                return
+//            }
+//
+//            activity.application.unregisterActivityLifecycleCallbacks(this)
+//            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+//        }
+//
+//        override fun getLifecycle(): Lifecycle {
+//            return lifecycle
+//        }
+//    }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
As discussed in https://github.com/juicycleff/flutter-unity-view-widget/issues/973, Flutter 3.24 causes kotlin compilation errors because of Androidx interface changes.

`FlutterUnityWidgetPlugin.kt:97:9 Cannot weaken access privilege 'public' for 'lifecycle' in 'LifecycleOwner'`
`FlutterUnityWidgetPlugin.kt:97:21 'lifecycle' hides member of supertype 'LifecycleOwner' and needs 'override' modifier`

Also requested in #975

## 
The last reference to the class using LifecycleOwner was removed [over 2 years ago](https://github.com/juicycleff/flutter-unity-view-widget/commit/e4cd05930a5dc7f0b4b9c8457061020e2d24a3fa)
Therefore the easiest fix is to get rid of it.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
