### PR TITLE
Anr fix poker

### DIFF
--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityPlayerUtils.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityPlayerUtils.kt
@@ -82,7 +82,7 @@ class UnityPlayerUtils {
         }
 
         fun postMessage(gameObject: String, methodName: String, message: String) {
-            if (unityPlayer == null || !unityLoaded || unityPaused == true) {
+            if (unityPlayer == null || !unityLoaded) {
                 return
             } 
             UnityPlayer.UnitySendMessage(gameObject, methodName, message)

--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityPlayerUtils.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/UnityPlayerUtils.kt
@@ -82,6 +82,9 @@ class UnityPlayerUtils {
         }
 
         fun postMessage(gameObject: String, methodName: String, message: String) {
+            if (unityPlayer == null || !unityLoaded || unityPaused == true) {
+                return
+            } 
             UnityPlayer.UnitySendMessage(gameObject, methodName, message)
         }
 


### PR DESCRIPTION
## Description

This PR introduces a fix for the ANR (Application Not Responding) issue: `com.unity3d.player.UnityPlayer.nativeRender` in the flutter_unity_widget package. The ANR issue was caused by attempting to send Unity messages when the Unity player was not properly loaded or initialized.

## Changes Made:

- Added a safety check before calling UnityPlayer.UnitySendMessage() to ensure that unityPlayer is not null and unityLoaded is true.

## Modified Function:

```
fun postMessage(gameObject: String, methodName: String, message: String) {
    if (unityPlayer == null || !unityLoaded) {
        return
    }
    UnityPlayer.UnitySendMessage(gameObject, methodName, message)
}
```

## Type of Change

## Motivation and Context

The ANR issue was reported with the following trace:

`com.unity3d.player.UnityPlayer.nativeRender (UnityPlayer.java)
com.unity3d.player.UnityPlayer$C$a.handleMessage (UnityPlayer.java:123)
android.os.Handler.dispatchMessage (Handler.java:102)
android.os.Looper.loopOnce (Looper.java:226)
android.os.Looper.loop (Looper.java:313)
com.unity3d.player.UnityPlayer$C.run (UnityPlayer.java:25)
`

By adding a check for unityPlayer and unityLoaded before sending messages, we prevent calls to Unity when it is not ready, thus mitigating the ANR.

## How Has This Been Tested?

- Manual Testing: Tested by launching the app multiple times and interacting with Unity features. No ANRs were observed.
- Automated Testing: Ran unit tests to ensure no regressions.

## Additional Notes

- This fix addresses the ANR without introducing any breaking changes.
- Verified compatibility with Unity versions 2021 and above.

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
