### PR TITLE
[Android] Fix build errors by defining kotlin jvmTarget.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,8 +51,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }
 


### PR DESCRIPTION

## Description

<!--- Describe your changes in detail -->
Add the following to the build.gradle of the plugin.
```
kotlinOptions {
    jvmTarget = JavaVersion.VERSION_1_8
}
```
This is present in newly created Flutter projects, just using a different version.


Because this value isn't currently defined, this can cause issues where the build tries to use different values for the java version and kotlin jvm version.

This leads to errors like 

#986
```
Execution failed for task ':flutter_unity_widget:compileDebugKotlin'.
> 'compileDebugJavaWithJavac' task (current target is 1.8) and 'compileDebugKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.
  Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain
```

In #992 on the Unity 6000 branch this caused:
```
Execution failed for task ':flutter_unity_widget:compileDebugKotlin'.
> Error while evaluating property 'compilerOptions.jvmTarget' of task ':flutter_unity_widget:compileDebugKotlin'.
   > Failed to calculate the value of property 'jvmTarget'.
      > Unknown Kotlin JVM target: 21
```

##

For now I simply use the same java version s used previously.  
This value will likely need to be updated in the future.
 
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
