### PR TITLE
[Flutter 3.29] Update docs and build.cs to handle Kotlin .gradle.kts files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,10 @@ This requires a flutter_unity_widget version that is newer than 2022.2.1.
 
 ```diff
      dependencies {
+         // build.gradle
 +        implementation project(':flutter_unity_widget')
+         // build.gradle.kts (Flutter 3.29+)
++        implementation(project(":flutter_unity_widget"))
      }
 ```
 - 3.2. Edit your android MainActivity file.  
@@ -241,7 +244,12 @@ But if you want to manually set up the changes made by the export, continue.
 5. Open the *android/settings.gradle* file and change the following:
 
 ```diff
+// build.gradle
 +    include ":unityLibrary"
++    project(":unityLibrary").projectDir = file("./unityLibrary")
+
+// build.gradle.kts (Flutter 3.29+)
++    include(":unityLibrary")
 +    project(":unityLibrary").projectDir = file("./unityLibrary")
 ```
 
@@ -249,7 +257,10 @@ But if you want to manually set up the changes made by the export, continue.
 
 ```diff
      dependencies {
+          // app/build.gradle
 +        implementation project(':unityLibrary')
+         // app/build.gradle.kts (Flutter 3.29+)
++        implementation(project(":unityLibrary"))
      }
 ```
 
@@ -259,7 +270,10 @@ But if you want to manually set up the changes made by the export, continue.
 allprojects {
     repositories {
 +       flatDir {
+            // build.gradle
 +           dirs "${project(':unityLibrary').projectDir}/libs"
+            // build.gradle.kts (Flutter 3.29+)
++           dirs(file("${project(":unityLibrary").projectDir}/libs"))
 +       }
         google()
         mavenCentral()
@@ -401,7 +415,11 @@ allprojects {
   3. If your `XR Plugin Management` plugin is version 4.4 or higher, Unity also exports the xrmanifest.androidlib folder.
      Make sure to include it by adding the following line to `android/settings.gradle`
      ```
+     // settings.gradle
      include ":unityLibrary:xrmanifest.androidlib"
+
+     // settings.gradle.kts (Flutter 3.29+)
+     include(":unityLibrary:xrmanifest.androidlib")
      ```
   4. With some Unity versions AR might crash at runtine with an error like:  
    `java.lang.NoSuchFieldError: no "Ljava/lang/Object;" field "mUnityPlayer" in class`.  

--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -514,6 +514,12 @@ body { padding: 0; margin: 0; overflow: hidden; }
             var appBuildPath = Path.Combine(androidAppPath, "build.gradle");
             var settingsPath = Path.Combine(androidPath, "settings.gradle");
 
+            // switch to Kotlin DSL gradle if .kts file is detected (Fluter 3.29+ by default)
+            if (File.Exists(projBuildPath + ".kts")) {
+                SetupAndroidProjectKotlin();
+                return;
+            }
+
             var projBuildScript = File.ReadAllText(projBuildPath);
             var settingsScript = File.ReadAllText(settingsPath);
             var appBuildScript = File.ReadAllText(appBuildPath);
@@ -567,6 +573,71 @@ dependencies {
             }
         }
 
+
+        // Copy of SetupAndroidProject() adapted to Kotlin DLS .gradle.kts. Generated since Flutter 3.29
+        private static void SetupAndroidProjectKotlin()
+        {
+            var androidPath = Path.GetFullPath(Path.Combine(ProjectPath, "../../android"));
+            var androidAppPath = Path.GetFullPath(Path.Combine(ProjectPath, "../../android/app"));
+            var projBuildPath = Path.Combine(androidPath, "build.gradle.kts");
+            var appBuildPath = Path.Combine(androidAppPath, "build.gradle.kts");
+            var settingsPath = Path.Combine(androidPath, "settings.gradle.kts");
+
+
+            var projBuildScript = File.ReadAllText(projBuildPath);
+            var settingsScript = File.ReadAllText(settingsPath);
+            var appBuildScript = File.ReadAllText(appBuildPath);
+
+            // Sets up the project build.gradle files correctly
+            if (!Regex.IsMatch(projBuildScript, @"flatDir[^/]*[^}]*}"))
+            {
+                var regex = new Regex(@"allprojects \{[^\{]*\{", RegexOptions.Multiline);
+                projBuildScript = regex.Replace(projBuildScript, @"
+allprojects {
+    repositories {
+        flatDir {
+            dirs(file(""${project("":unityLibrary"").projectDir}/libs""))
+        }
+");
+                File.WriteAllText(projBuildPath, projBuildScript);
+            }
+
+            // Sets up the project settings.gradle files correctly
+            if (!Regex.IsMatch(settingsScript, @"include("":unityLibrary"")"))
+            {
+                settingsScript += @"
+
+include("":unityLibrary"")
+project("":unityLibrary"").projectDir = file(""./unityLibrary"")
+";
+                File.WriteAllText(settingsPath, settingsScript);
+            }
+
+
+            // Sets up the project app build.gradle files correctly
+            if (!Regex.IsMatch(appBuildScript, @"dependencies \{"))
+            {
+                appBuildScript += @"
+dependencies {
+    implementation(project("":unityLibrary""))
+}
+";
+                File.WriteAllText(appBuildPath, appBuildScript);
+            }
+            else
+            {
+                if (!appBuildScript.Contains(@"implementation(project("":unityLibrary"")"))
+                {
+                    var regex = new Regex(@"dependencies \{", RegexOptions.Multiline);
+                    appBuildScript = regex.Replace(appBuildScript, @"
+dependencies {
+    implementation(project("":unityLibrary""))
+");
+                    File.WriteAllText(appBuildPath, appBuildScript);
+                }
+            }
+        }
+
         /// <summary>
         /// This method tries to autome the build setup required for Android
         /// </summary>
@@ -575,6 +646,11 @@ dependencies {
             var androidPath = Path.GetFullPath(Path.Combine(ProjectPath, "../../android"));
             var projBuildPath = Path.Combine(androidPath, "build.gradle");
             var settingsPath = Path.Combine(androidPath, "settings.gradle");
+
+            if (File.Exists(projBuildPath + ".kts")) {
+                SetupAndroidProjectForPluginKotlin();
+                return;
+            }
 
             var projBuildScript = File.ReadAllText(projBuildPath);
             var settingsScript = File.ReadAllText(settingsPath);
@@ -597,6 +673,40 @@ dependencies {
                 settingsScript += @"
 
 include "":unityLibrary""
+project("":unityLibrary"").projectDir = file(""./unityLibrary"")
+";
+                File.WriteAllText(settingsPath, settingsScript);
+            }
+        }
+
+        // Copy of SetupAndroidProjectForPlugin() adapted to Kotlin DLS .gradle.kts. Generated since Flutter 3.29
+        private static void SetupAndroidProjectForPluginKotlin()
+        {
+            var androidPath = Path.GetFullPath(Path.Combine(ProjectPath, "../../android"));
+            var projBuildPath = Path.Combine(androidPath, "build.gradle.kts");
+            var settingsPath = Path.Combine(androidPath, "settings.gradle.kts");
+
+            var projBuildScript = File.ReadAllText(projBuildPath);
+            var settingsScript = File.ReadAllText(settingsPath);
+
+            // Sets up the project build.gradle files correctly
+            if (Regex.IsMatch(projBuildScript, @"// BUILD_ADD_UNITY_LIBS"))
+            {
+                var regex = new Regex(@"// BUILD_ADD_UNITY_LIBS", RegexOptions.Multiline);
+                projBuildScript = regex.Replace(projBuildScript, @"
+        flatDir {
+            dirs(file(""${project("":unityLibrary"").projectDir}/libs""))
+        }
+");
+                File.WriteAllText(projBuildPath, projBuildScript);
+            }
+
+            // Sets up the project settings.gradle files correctly
+            if (!Regex.IsMatch(settingsScript, @"include("":unityLibrary"")"))
+            {
+                settingsScript += @"
+
+include("":unityLibrary"")
 project("":unityLibrary"").projectDir = file(""./unityLibrary"")
 ";
                 File.WriteAllText(settingsPath, settingsScript);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Since Flutter 3.29, new projects will use the Kotin gradle DSL.  
Files like `build.gradle` and `settings.gradle` now have a `.gradle.kts` extension.


Besides the file extension change, the syntax is different.

For example:
```diff
- implementation project(':unityLibrary')
+ implementation(project(":unityLibrary"))
````

```diff
flatDir {
-    dirs "${project(':unityLibrary').projectDir}/libs"
+    dirs(file("${project(":unityLibrary").projectDir}/libs"))
}
```

This leads to issue like #1002


This PR:
- Adds the new syntax in the README.
- Make `build.cs` capable of  adjusting `.gradle.kts` files in the Unity export.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore

##
I did not test the Unity `Export Android Plugin` option, as I'm not sure how that is used.  
But I did update it with the same changes as the regular Android (debug/release) export, which I did test.

##
The example project needs to be updated before it will be compatible with Flutter 3.29.
For a new Flutter 3.29 project this PR is enough.   

With Flutter 3.29 you will likely have to define `ndkVersion` in `app/build.gradle.kts`.
In my case, the Flutter console error messages told me to use `ndkVersion = "27.0.12077973"`.
