### PR TITLE
[Android] Add export check for "game_view_content_description" in strings.xml

### DIFF
--- a/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
+++ b/example/unity/DemoApp/Assets/FlutterUnityIntegration/Editor/Build.cs
@@ -367,6 +367,21 @@ body { padding: 0; margin: 0; overflow: hidden; }
             var proguardText = File.ReadAllText(proguardFile);
 	    proguardText = proguardText.Replace("-ignorewarnings", "-keep class com.xraph.plugin.** { *; }\n-keep class com.unity3d.plugin.* { *; }\n-ignorewarnings");
             File.WriteAllText(proguardFile, proguardText);
+
+            // Make sure "game_view_content_description" is in strings.xml
+            var stringsFile = Path.Combine(APKPath, "launcher", "src", "main", "res", "values", "strings.xml");
+            if(File.Exists(stringsFile))
+            {
+                var stringsText = File.ReadAllText(stringsFile);
+                if(!stringsText.Contains("game_view_content_description"))
+                {
+                    stringsText = stringsText.Replace("<resources>", "<resources>\n  <string name=\"game_view_content_description\">Game view</string>");
+                    File.WriteAllText(stringsFile, stringsText);
+                }
+            } else
+            {
+                Debug.LogError("Android res/values/strings.xml file not found during export.");
+            }     
         }
 
         private static void BuildIOS(String path, bool isReleaseBuild)

--- a/unitypackages/README.md
+++ b/unitypackages/README.md
@@ -33,7 +33,7 @@ Changes for `2022.1.7f1` and earlier were collected retroactively and might not 
 
 ## Pending (master branch)
 > Example Unity project, not in a unitypackage yet.
-* *No changes*
+* (Android) Handle missing `"game_view_content_description"` string in Unity output strings.xml.
 
 ## 2022.3.0
 >fuw-2022.3.0.unitypackage
@@ -43,6 +43,7 @@ Changes for `2022.1.7f1` and earlier were collected retroactively and might not 
 * (Web) Fix Javascript error on Play and Pause.
 * (Android) Fix build error `resource style/UnityThemeSelector not found` in the example project.
 * Use Il2CppCodeGeneration.OptimizeSpeed in Android and iOS release exports.
+* (Android) Handle new .gradle.kts files in Flutter 3.29+.
 
 
 ## 2022.2.0


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Sometimes a Unity Android export will randomly omit the string `"game_view_content_description"` from the strings.xml file in the output.

This is the expected output:  
`android/unityLibrary/src/main/res/values/strings.xml`
```
<?xml version="1.0" encoding="utf-8"?>
<resources>
  <string name="app_name">flutterunitywidgets</string>
  <string name="game_view_content_description">Game view</string>
</resources>
```

If this string is missing you will get an error like:
```
E/AndroidRuntime(31563): android.content.res.Resources$NotFoundException: String resource ID #0x0
E/AndroidRuntime(31563): 	at android.content.res.Resources.getText(Resources.java:367)
E/AndroidRuntime(31563): 	at android.content.res.Resources.getString(Resources.java:460)
E/AndroidRuntime(31563): 	at com.unity3d.player.UnityPlayer.GetGlViewContentDescription(Unknown Source:20)
E/AndroidRuntime(31563): 	at com.unity3d.player.UnityPlayer.<init>(Unknown Source:271)
E/AndroidRuntime(31563): 	at com.xraph.plugin.flutter_unity_widget.UnityPlayerUtils$Companion$createPlayer$1.run(UnityPlayerUtils.kt:45)
E/AndroidRuntime(31563): 	at android.os.Handler.handleCallback(Handler.java:883)
E/AndroidRuntime(31563): 	at android.os.Handler.dispatchMessage(Handler.java:100)
E/AndroidRuntime(31563): 	at android.os.Looper.loop(Looper.java:214)
E/AndroidRuntime(31563): 	at android.app.ActivityThread.main(ActivityThread.java:7697)
E/AndroidRuntime(31563): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(31563): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:516)
E/AndroidRuntime(31563): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
```


I can find stackoverflow and github issues with this error back to Unity 2018, but I have never managed to reproduce it myself. 
Because of that I have no clue what exactly causes this, just that it happens to some people.
   
This has been popping up again recently [here](
https://github.com/juicycleff/flutter-unity-view-widget/issues/967#issuecomment-2700130195) and on Discord, even for Unity 6.

##
Some old issues and mentions include:
- https://github.com/juicycleff/flutter-unity-view-widget/issues/516  
- https://github.com/juicycleff/flutter-unity-view-widget/issues/984#issuecomment-2358818565  
- https://github.com/juicycleff/flutter-unity-view-widget/issues/651  
- https://github.com/Unity-Technologies/uaal-example/issues/48  
- https://discussions.unity.com/t/unity-2018-3-6-upgrade-to-unity-2018-4-has-bug/744165/4  
- https://stackoverflow.com/questions/56416191/resource-not-found-exception-while-opening-unity-project-in-android-studio  

## Fix
This change adds the string to `strings.xml` if it is detected as missing.  
It will also log an error to the console if the entire file is somehow missing.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
