### PR TITLE
Fix loadedCallbackPending logic to properly prevent frame invalidation during Unity player creation

### DIFF
--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetController.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetController.kt
@@ -285,10 +285,12 @@ class FlutterUnityWidgetController(
     private fun createPlayer() {
         try {
             if (UnityPlayerUtils.activity != null) {
+                loadedCallbackPending = true
                 UnityPlayerUtils.createUnityPlayer( this, object : OnCreateUnityViewCallback {
                     override fun onReady() {
                         // attach unity to controller
                         attachToView()
+                        loadedCallbackPending = false
 
                         if (methodChannelResult != null) {
                             methodChannelResult!!.success(true)
@@ -298,6 +300,7 @@ class FlutterUnityWidgetController(
                 })
             }
         } catch (e: Exception) {
+            loadedCallbackPending = false
             if (methodChannelResult != null) {
                 methodChannelResult!!.error("FLUTTER_UNITY_WIDGET", e.message, e)
                 methodChannelResult!!.success(false)
@@ -372,7 +375,6 @@ class FlutterUnityWidgetController(
             return
         }
 
-        loadedCallbackPending = false
         postFrameCallback {
             postFrameCallback {
                 view.invalidate()


### PR DESCRIPTION
# Description

## Problem
The loadedCallbackPending variable was not being properly managed, causing potential race conditions and unnecessary frame invalidation calls during Unity player initialization. The variable was set to true in createPlayer() but the guard condition in invalidateFrameIfNeeded() was ineffective because:

The variable was being reset to false immediately after the guard check instead of when the callback actually completed
This could lead to frame invalidation attempts while Unity player creation was still in progress
The logic didn't align with the intended behavior referenced from Google Maps implementation

## Solution
- Properly set `loadedCallbackPending = true` when Unity player creation begins
- Reset `loadedCallbackPending = false` only when the `OnCreateUnityViewCallback.onReady()` is called or on error
- Remove the incorrect reset in `invalidateFrameIfNeeded()` method

## Related Issues
Fixes potential race conditions during Unity player initialization that could cause rendering issues or crashes.

## Type of Change
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
