### PR TITLE
Chore: Update Flutter version in github action.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.3.0'
+          flutter-version: '3.24.5'
           channel: 'stable'
 
       - name: Clean Dependencies
@@ -21,7 +21,7 @@ jobs:
         run: flutter packages get
 
       - name: Format
-        run: flutter format --set-exit-if-changed lib test
+        run: dart format --set-exit-if-changed lib test
 
       - name: Analyze
         run: flutter analyze lib test

--- a/test/fake_unity_widget_controllers.dart
+++ b/test/fake_unity_widget_controllers.dart
@@ -7,7 +7,8 @@ class FakePlatformUnityWidget {
   FakePlatformUnityWidget(int id, Map<dynamic, dynamic> params)
       : channel = MethodChannel(
             'plugin.xraph.com/unity_view_$id', const StandardMethodCodec()) {
-    channel.setMockMethodCallHandler(onMethodCall);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, onMethodCall);
   }
 
   MethodChannel channel;

--- a/test/flutter_unity_widget_test.dart
+++ b/test/flutter_unity_widget_test.dart
@@ -16,8 +16,9 @@ Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() {
-    SystemChannels.platform_views.setMockMethodCallHandler(
-        fakePlatformViewsController.fakePlatformViewsMethodHandler);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform_views,
+            fakePlatformViewsController.fakePlatformViewsMethodHandler);
   });
 
   setUp(() {
@@ -25,7 +26,8 @@ Future<void> main() async {
   });
 
   tearDown(() {
-    channel.setMockMethodCallHandler(null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
   });
 
   testWidgets('Unity widget ready', (WidgetTester tester) async {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
The github action 'genopets', that checks all pull requests and commits on master, is still running Flutter 3.3.0.
This will lead to instant rejections when using Flutter or Dart sdk features that surpass this, like here https://github.com/juicycleff/flutter-unity-view-widget/pull/1028.

- I updated the Flutter version to 3.24.5.
- `flutter format` is replaced by `dart format` for compatibility with newer Flutter versions.
- `setMockMethodCallHandler` is replaced in the tests. This is deprected since Flutter 3.9 and will throw warnings in `dart analyze`.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
