### PR TITLE
Update android compileSdk and Java version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [Android] Add namespace for Android gradle plugin (AGP) 8 compatibility.
 * [Android] Fix kotlin compilation error with Flutter 3.24 and newer. [#973](https://github.com/juicycleff/flutter-unity-view-widget/issues/973)
 * [Android] Update documentation for new `.gradle.kts` files.
+* [Android] Update some ancient build.gradle values to match Unity 2022.3. Like CompileSdk to 34 and Java to 11.
 * [iOS] Add an empty privacy manifest.
 * [Web] Don't crash on unknown event data from Unity.
 * Disable windows support in `pubspec.yaml` to avoid confusion. Windows support was never completed.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,15 +1,15 @@
 group 'com.xraph.plugin.flutter_unity_widget'
-version '4.0-SNAPSHOT'
+version '2022.2.2-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -33,7 +33,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 34
 
     // backwards compatible for old gradle versions without namespace
     if (project.android.hasProperty("namespace")) {
@@ -51,12 +51,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -12,13 +12,13 @@ android {
     // ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
         // if you change this value, also change it in android/build.gradle subprojects{}
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     defaultConfig {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -34,7 +34,7 @@ subprojects {
                 }
                 project.android.kotlinOptions {
                     // if you change this value, also change it in android/app/build.gradle
-                    jvmTarget = JavaVersion.VERSION_1_8
+                    jvmTarget = JavaVersion.VERSION_11.toString()
                 }
             }
         }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Updated some values in the outdated build.gradle of the plugin.
The example was updated to match it.

##
* Updated compileSdk to 34.  

The plugin is still at compileSdk 29.
34 is currently the minimum for a project to publish on the Play Store, and that is soon to be 35.

Some errors (like #845, #870) are directly caused by this low sdk.

##
* Updated Java 8 to 11

Unity 2021.3 and 2022.3  [both use Java 11](https://docs.unity3d.com/2022.3/Documentation/Manual/android-supported-dependency-versions.html).

And i'm also getting console warnings about Java 8 like:
```
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
```

I can still make a release build with the plugin at Java 11 and my Flutter project at Java 8.  So this is (partially?) backwards compatible.

##

I updated the kotling and AGP version to be somewhat in line with these changes.  
These don't seem to matter much as Flutter projects on much newer Kotlin or AGP versions never show any warnings or errors related to them.
Just to be safe, I kept AGP below 8.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
