### PR TITLE
Fix error after flutter pub downgrade.

### DIFF
--- a/lib/src/web/web_unity_widget_controller.dart
+++ b/lib/src/web/web_unity_widget_controller.dart
@@ -256,7 +256,8 @@ class WebUnityWidgetController extends UnityWidgetController {
         .querySelector('flt-platform-view')
         ?.querySelector('iframe');
 
-    if (frame != null && _isJsObjectOfType(frame, 'HTMLIFrameElement')) {
+    final JSAny? jsFrame = frame.jsify();
+    if (frame != null && _isJsObjectOfType(jsFrame, 'HTMLIFrameElement')) {
       (frame as web.HTMLIFrameElement).focus();
     }
   }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
#1034 works fine after a `flutter pub get` but introduced an error if you run `flutter pub downgrade`.

```
ARGUMENT_TYPE_NOT_ASSIGNABLE - lib/src/web/web_unity_widget_controller.dart:259:44 - The argument type 'Element' can't be assigned to the parameter type 'JSAny?'`
```

This is a quick fix.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
